### PR TITLE
Use stable API endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "0.0.4",
+  "version": "0.1.0-alpha.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -34,8 +34,8 @@
     "clsx": "^1.1.1",
     "material-table": "^1.69.2",
     "moment": "^2.29.1",
+    "rc-progress": "^3.1.4",
     "react": "^16.13.1",
-    "react-circular-progressbar": "^2.0.4",
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",
     "react-router-dom": "6.0.0-beta.0",

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -36,28 +36,30 @@ export class CortexClient implements CortexApi {
   }
 
   async getScorecards(): Promise<Scorecard[]> {
-    return await this.get(`/api/internal/v1/scorecards`);
+    return await this.get(`/api/backstage/v1/scorecards`);
   }
 
   async syncEntities(entities: Entity[]): Promise<void> {
-    return await this.post(`/api/internal/v1/backstage`, {
+    return await this.post(`/api/backstage/v1/entities`, {
       entities: entities,
     });
   }
 
   async getServiceScores(
-    service: string,
+    entityRef: string,
   ): Promise<ServiceScorecardScore[] | undefined> {
-    return await this.get(`/api/v1/services/tags/${service}/scorecards`);
+    return await this.get(`/api/backstage/v1/entities/scorecards`, {
+      ref: entityRef
+    });
   }
 
 
   async getScorecard(scorecardId: string): Promise<Scorecard> {
-    return await this.get(`/api/internal/v1/scorecards/${scorecardId}`);
+    return await this.get(`/api/backstage/v1/scorecards/${scorecardId}`);
   }
 
   async getScorecardScores(scorecardId: string): Promise<ScorecardServiceScore[]> {
-    return await this.get(`/api/internal/v1/scorecards/${scorecardId}/scores`);
+    return await this.get(`/api/backstage/v1/scorecards/${scorecardId}/scores`);
   }
 
   private async getBasePath(): Promise<string> {
@@ -65,11 +67,19 @@ export class CortexClient implements CortexApi {
     return `${proxyBasePath}/cortex`;
   }
 
-  private async get(path: string): Promise<any | undefined> {
+  private async get(path: string, args?: { [key: string]: string }): Promise<any | undefined> {
     const basePath = await this.getBasePath();
-    const url = `${basePath}${path}`;
 
-    const response = await fetch(url);
+    const url = `${basePath}${path}`;
+    const queryUrl = args
+      ? `${url}?${ 
+      Object.keys(args)
+        .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(args[key])}`)
+        .join('&')}`
+      : url;
+
+
+    const response = await fetch(queryUrl);
     const body = await response.json();
 
     if (response.status === 404) {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -19,7 +19,7 @@ export interface Scorecard {
   name: string;
   description?: string;
   rules: Rule[];
-  serviceGroups: ServiceGroup[];
+  tags: ServiceGroup[];
   nextUpdated?: string;
 }
 
@@ -51,16 +51,14 @@ export interface ServiceScorecardScore {
 
 export interface ScorecardServiceScore {
   serviceId: string;
-  serviceName: string;
-  serviceTag: string;
-  serviceGroups?: string[];
-  ownerGroups?: string[];
+  componentRef: string;
   scorecardId: string;
   score: number;
   scorePercentage: number;
   totalPossibleScore: number;
   rules: ScorecardServiceScoresRule[];
   lastUpdated: string;
+  tags: string[];
 }
 
 export interface ScorecardServiceScoresRule {

--- a/src/components/CortexComponentsTable/CortexComponentsTable.tsx
+++ b/src/components/CortexComponentsTable/CortexComponentsTable.tsx
@@ -51,7 +51,7 @@ const columns: TableColumn<CortexScorecardsRow>[] = [
   },
 ];
 
-export const CortexScorecardsTable = ({
+export const CortexComponentsTable = ({
   error,
   loading,
   entityScores,

--- a/src/components/CortexComponentsTable/CortexScorecardScoresColumn.tsx
+++ b/src/components/CortexComponentsTable/CortexScorecardScoresColumn.tsx
@@ -16,9 +16,11 @@
 import React from 'react';
 import { ServiceScorecardScore } from '../../api/types';
 import Box from '@material-ui/core/Box';
-import { CircularProgressbar } from 'react-circular-progressbar';
-import 'react-circular-progressbar/dist/styles.css';
-import { Button, TableCell, Tooltip } from '@material-ui/core';
+import { TableCell, Tooltip } from '@material-ui/core';
+import { Button } from '@backstage/core-components';
+import { Gauge } from "../Gauge";
+import { useRouteRef } from "@backstage/core-plugin-api";
+import { scorecardRouteRef } from "../../routes";
 
 type CortexScorecardScoresColumnProps = {
   scores: ServiceScorecardScore[] | undefined;
@@ -27,6 +29,9 @@ type CortexScorecardScoresColumnProps = {
 export const CortexScorecardScoresColumn = ({
   scores,
 }: CortexScorecardScoresColumnProps) => {
+
+  const scorecardRef = useRouteRef(scorecardRouteRef)
+
   if (scores === undefined) {
     return <div>Service is not synced with Cortex</div>;
   } else if (scores.length === 0) {
@@ -46,14 +51,8 @@ export const CortexScorecardScoresColumn = ({
             >
               <Box alignSelf="center">
                 <Tooltip title={score.scorecardName}>
-                  <Button
-                    href={`https://app.getcortexapp.com/admin/scorecards/${score.scorecardId}`}
-                  >
-                    <CircularProgressbar
-                      value={score.scorePercentage * 100}
-                      text={`${(score.scorePercentage * 100).toFixed(2)}%`}
-                      strokeWidth={5}
-                    />
+                  <Button to={scorecardRef({ id: score.scorecardId })} color="primary">
+                    <Gauge value={score.scorePercentage} strokeWidth={6} trailWidth={6}/>
                   </Button>
                 </Tooltip>
               </Box>

--- a/src/components/CortexComponentsTable/index.ts
+++ b/src/components/CortexComponentsTable/index.ts
@@ -13,13 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Scorecard, ScorecardServiceScore, ServiceScorecardScore } from './types';
-import { Entity } from '@backstage/catalog-model';
-
-export interface CortexApi {
-  getScorecards(): Promise<Scorecard[]>
-  getScorecard(scorecardId: string): Promise<Scorecard | undefined>
-  getScorecardScores(scorecardId: string): Promise<ScorecardServiceScore[] | undefined>
-  getServiceScores(entityRef: string): Promise<ServiceScorecardScore[] | undefined>;
-  syncEntities(entities: Entity[]): Promise<void>;
-}
+export { CortexComponentsTable } from './CortexComponentsTable';

--- a/src/components/CortexFetchComponent/CortexFetchComponent.tsx
+++ b/src/components/CortexFetchComponent/CortexFetchComponent.tsx
@@ -18,7 +18,8 @@ import { useApi } from '@backstage/core';
 import { useAsync } from 'react-use';
 import { cortexApiRef } from '../../api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
-import { CortexScorecardsTable } from '../CortexScorecardsTable/CortexScorecardsTable';
+import { CortexComponentsTable } from '../CortexComponentsTable/CortexComponentsTable';
+import { stringifyEntityRef } from "@backstage/catalog-model";
 
 export const CortexFetchComponent = () => {
   const catalogApi = useApi(catalogApiRef);
@@ -31,7 +32,7 @@ export const CortexFetchComponent = () => {
 
     return await Promise.all(
       entities.map(async entity => {
-        const scores = await cortexApi.getServiceScores(entity.metadata.name);
+        const scores = await cortexApi.getServiceScores(stringifyEntityRef(entity));
         return { entity, scores };
       }),
     );
@@ -40,7 +41,7 @@ export const CortexFetchComponent = () => {
   const entities = (value ?? []).map(entityScore => entityScore.entity);
 
   return (
-    <CortexScorecardsTable
+    <CortexComponentsTable
       entityScores={value ?? []}
       loading={loading}
       error={error}

--- a/src/components/Gauge/Gauge.tsx
+++ b/src/components/Gauge/Gauge.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { makeStyles, useTheme } from '@material-ui/core';
+import { BackstageTheme } from '@backstage/theme';
+import { Circle } from 'rc-progress';
+import React from 'react';
+
+
+const useStyles = makeStyles<BackstageTheme>(theme => ({
+  root: {
+    position: 'relative',
+    lineHeight: 0,
+  },
+  overlay: {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -60%)',
+    fontWeight: 'bold',
+    color: theme.palette.textContrast,
+  },
+  circle: {
+    width: '80%',
+    transform: 'translate(10%, 0)',
+  },
+  colorUnknown: {},
+}));
+
+type Props = {
+  value: number;
+  fractional?: boolean;
+  inverse?: boolean;
+  unit?: string;
+  max?: number;
+  strokeWidth?: number;
+  trailWidth?: number;
+};
+
+const defaultProps = {
+  fractional: true,
+  inverse: false,
+  unit: '%',
+  max: 100,
+};
+
+export function getProgressColor(
+  palette: BackstageTheme['palette'],
+  value: number,
+  inverse?: boolean,
+  max?: number,
+) {
+  if (isNaN(value)) {
+    return '#ddd';
+  }
+
+  const actualMax = max ? max : defaultProps.max;
+  const actualValue = inverse ? actualMax - value : value;
+
+  if (actualValue < actualMax / 3) {
+    return palette.status.error;
+  } else if (actualValue < actualMax * (2 / 3)) {
+    return palette.status.warning;
+  }
+
+  return palette.status.ok;
+}
+
+// TODO: Cut PR back upstream
+export const Gauge = (props: Props) => {
+  const classes = useStyles(props);
+  const theme = useTheme<BackstageTheme>();
+  const { value, fractional, inverse, unit, max } = {
+    ...defaultProps,
+    ...props,
+  };
+
+  const asPercentage = fractional ? Math.round(value * max) : value;
+  const asActual = max !== 100 ? Math.round(value) : asPercentage;
+
+  return (
+    <div className={classes.root}>
+      <Circle
+        strokeLinecap="butt"
+        percent={asPercentage}
+        strokeWidth={props.strokeWidth ?? 12}
+        trailWidth={props.trailWidth ?? 12}
+        strokeColor={getProgressColor(theme.palette, asActual, inverse, max)}
+        className={classes.circle}
+      />
+      <div className={classes.overlay}>
+        {isNaN(value) ? 'N/A' : `${asActual}${unit}`}
+      </div>
+    </div>
+  );
+};
+

--- a/src/components/Gauge/index.ts
+++ b/src/components/Gauge/index.ts
@@ -13,13 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Scorecard, ScorecardServiceScore, ServiceScorecardScore } from './types';
-import { Entity } from '@backstage/catalog-model';
-
-export interface CortexApi {
-  getScorecards(): Promise<Scorecard[]>
-  getScorecard(scorecardId: string): Promise<Scorecard | undefined>
-  getScorecardScores(scorecardId: string): Promise<ScorecardServiceScore[] | undefined>
-  getServiceScores(entityRef: string): Promise<ServiceScorecardScore[] | undefined>;
-  syncEntities(entities: Entity[]): Promise<void>;
-}
+export { Gauge } from './Gauge';

--- a/src/components/Scorecards/ScorecardCard/ScorecardCard.tsx
+++ b/src/components/Scorecards/ScorecardCard/ScorecardCard.tsx
@@ -19,16 +19,15 @@ import React from 'react';
 import { Button, ItemCardHeader } from '@backstage/core-components';
 import { Scorecard } from "../../../api/types";
 import { useRouteRef } from "@backstage/core-plugin-api";
-import { rootRouteRef } from "../../../routes";
+import { scorecardRouteRef } from "../../../routes";
 
 type ScorecardCardProps = {
   scorecard: Scorecard;
 };
 
-// TODO: Use subRouteRefs, currently RoutedTabs doesn't update URL to default to first tab
 export const ScorecardCard = ({ scorecard }: ScorecardCardProps) => {
 
-  const root = useRouteRef(rootRouteRef)
+  const scorecardRef = useRouteRef(scorecardRouteRef)
 
   return (
     <Card>
@@ -39,7 +38,8 @@ export const ScorecardCard = ({ scorecard }: ScorecardCardProps) => {
         {scorecard.description}
       </CardContent>
       <CardActions>
-        <Button to={`${root()}/scorecards/${scorecard.id}`} color="primary">
+
+        <Button to={scorecardRef({ id: scorecard.id })} color="primary">
           Details
         </Button>
       </CardActions>

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardMetadataCard/ScorecardMetadataCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardMetadataCard/ScorecardMetadataCard.tsx
@@ -47,9 +47,9 @@ export const ScorecardMetadataCard = ({
         <ScorecardMetadataItem gridSizes={{ xs: 12, sm: 6, lg: 4 }} label="Owner">
           {scorecard.creator.name}
         </ScorecardMetadataItem>
-        { scorecard.serviceGroups.length > 0 && (
+        { scorecard.tags.length > 0 && (
           <ScorecardMetadataItem gridSizes={{ xs: 12, sm: 6, lg: 4 }} label="Applies To">
-            {scorecard.serviceGroups.map(s => (
+            {scorecard.tags.map(s => (
               <Chip key={s.id} size="small" label={s.tag} />
             ))}
           </ScorecardMetadataItem>

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableCard.tsx
@@ -17,7 +17,7 @@ import { InfoCard } from "@backstage/core";
 import React from "react";
 import { ScorecardServiceScore } from "../../../../api/types";
 import { useScorecardDetailCardStyles } from "../../../../styles/styles";
-import { Table } from "@material-ui/core";
+import { Table, TableBody } from "@material-ui/core";
 import { ScorecardsTableRow } from "./ScorecardsTableRow";
 
 interface ScorecardsTableProps {
@@ -33,9 +33,11 @@ export const ScorecardsTableCard = ({
   return (
     <InfoCard title="Scores" className={classes.root}>
       <Table>
-        { scores.map(score => (
-          <ScorecardsTableRow key={score.serviceId} score={score}/>
-        ))}
+        <TableBody>
+          { scores.map(score => (
+            <ScorecardsTableRow key={score.serviceId} score={score}/>
+          ))}
+        </TableBody>
       </Table>
     </InfoCard>
   )

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableRow.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableRow.tsx
@@ -18,9 +18,11 @@ import { ScorecardServiceScore } from "../../../../api/types";
 import { Collapse, IconButton, makeStyles, TableCell, TableRow } from "@material-ui/core";
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
-import { CircularProgressbar } from "react-circular-progressbar";
 import Box from "@material-ui/core/Box";
 import { ScorecardsTableRowDetails } from "./ScorecardsTableRowDetails";
+import { EntityRefLink } from "@backstage/plugin-catalog-react";
+import { parseEntityRef } from "@backstage/catalog-model";
+import { Gauge } from "../../../Gauge";
 
 const useStyles = makeStyles({
   root: {
@@ -50,7 +52,7 @@ export const ScorecardsTableRow = ({
   const [open, setOpen] = useState(false)
 
   return (
-    <>
+    <React.Fragment>
       <TableRow className={classes.root}>
         <TableCell className={classes.openIcon}>
           <IconButton size="small" onClick={() => setOpen(!open)}>
@@ -64,22 +66,17 @@ export const ScorecardsTableRow = ({
             justifyContent="flex-start"
             alignItems="center"
           >
-            <Box alignSelf="center">
-              <CircularProgressbar
-                value={score.scorePercentage * 100}
-                text={`${(score.scorePercentage * 100).toFixed(0)}%`}
-                strokeWidth={5}
-                className={classes.progress}
-                styles={{
-                  text: {
-                    fontSize: '24px'
-                  }
-                }}
-              />
+            <Box alignSelf="center" width={1/8}>
+              <Gauge value={score.scorePercentage} strokeWidth={8} trailWidth={8}/>
             </Box>
             <Box alignSelf="center">
-              {/* TODO: Replace with EntityRefLink*/ }
-              { score.serviceName }
+              <EntityRefLink
+                entityRef={parseEntityRef(score.componentRef, { defaultKind: 'Component', defaultNamespace: 'default' })}
+                defaultKind="Component"
+                style={{
+                  fontWeight: 'bold'
+                }}
+              />
             </Box>
           </Box>
         </TableCell>
@@ -91,6 +88,6 @@ export const ScorecardsTableRow = ({
           </Collapse>
         </TableCell>
       </TableRow>
-    </>
+    </React.Fragment>
   )
 }

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableRowDetails.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableRowDetails.tsx
@@ -15,7 +15,7 @@
  */
 import React from "react";
 import { ruleName, ScorecardServiceScore } from "../../../../api/types";
-import { Grid, List, ListItem, ListItemAvatar, ListItemText, makeStyles } from "@material-ui/core";
+import { Grid, List, ListItem, ListItemAvatar, ListItemText, makeStyles, Typography } from "@material-ui/core";
 import ErrorIcon from '@material-ui/icons/Error';
 import CheckIcon from '@material-ui/icons/Check';
 
@@ -56,12 +56,19 @@ export const ScorecardsTableRowDetails = ({
             { rule.score > 0 ? <CheckIcon color="primary"/> : <ErrorIcon color="error"/> }
           </ListItemAvatar>
           <Grid container direction="row" justify="space-between" alignItems="center" className={classes.rule}>
-            <Grid item>
+            <Grid item xs={9}>
               <ListItemText primary={ruleName(rule.rule)}/>
             </Grid>
             <Grid item>
               <ListItemText primary={`${rule.score}`}/>
             </Grid>
+            { rule.error && (
+              <Grid item xs={10}>
+                <Typography color="error">
+                  { rule.error }
+                </Typography>
+              </Grid>
+            )}
           </Grid>
         </ListItem>
       ))}

--- a/src/components/Scorecards/ScorecardsPage/ScorecardsPage.test.tsx
+++ b/src/components/Scorecards/ScorecardsPage/ScorecardsPage.test.tsx
@@ -32,7 +32,7 @@ describe('ScorecardsPage', () => {
           name: 'My Scorecard',
           description: 'Some description',
           rules: [],
-          serviceGroups: [],
+          tags: [],
           nextUpdated: "2021-08-25T04:00:00",
         }
       ]

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -30,7 +30,7 @@ export const cortexPlugin = createPlugin({
   routes: {
     root: rootRouteRef,
     scorecards: scorecardsRouteRef,
-    'scorecards/:id': scorecardRouteRef,
+    scorecard: scorecardRouteRef,
   },
 });
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -26,9 +26,9 @@ export const scorecardsRouteRef = createSubRouteRef({
   path: '/scorecards',
 });
 
-export const scorecardRouteRef = createRouteRef({
+export const scorecardRouteRef = createSubRouteRef({
   id: 'scorecard',
-  params: ['id'],
-  path: '/cortex/scorecards/:id/*',
+  path: '/scorecards/:id',
+  parent: rootRouteRef,
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10888,7 +10888,7 @@ raw-loader@^4.0.1:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-rc-progress@^3.0.0:
+rc-progress@^3.0.0, rc-progress@^3.1.4:
   version "3.1.4"
   resolved "https://registry.npmjs.org/rc-progress/-/rc-progress-3.1.4.tgz#66040d0fae7d8ced2b38588378eccb2864bad615"
   integrity sha512-XBAif08eunHssGeIdxMXOmRQRULdHaDdIFENQ578CMb4dyewahmmfJRyab+hw4KH4XssEzzYOkAInTLS7JJG+Q==
@@ -10921,11 +10921,6 @@ react-beautiful-dnd@^13.0.0:
     react-redux "^7.2.0"
     redux "^4.0.4"
     use-memo-one "^1.1.1"
-
-react-circular-progressbar@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.0.4.tgz#5b04a9cf6be8c522c180e4e99ec6db63677335b0"
-  integrity sha512-OfX0ThSxRYEVGaQSt0DlXfyl5w4DbXHsXetyeivmoQrh9xA9bzVPHNf8aAhOIiwiaxX2WYWpLDB3gcpsDJ9oww==
 
 react-dev-utils@^11.0.4:
   version "11.0.4"


### PR DESCRIPTION
Major changes:
* Use new stable Cortex endpoints
* Send entire set of entities for Cortex sync (to build up full graph of dependencies, systems, etc)

Small UI fixes:
* Use standard Gauge component (TODO: need to merge back upstream to Backstage)
![image](https://user-images.githubusercontent.com/2001609/131706343-270cb26e-3c2f-411e-9979-1bee16e6d0bd.png)
* Deep linking to components and within plugin
* Show errors for failing scorecard rules