### PR TITLE
Backstage component scorecard widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,17 @@ import { EntityCortexContent } from '@cortexapps/backstage-plugin';
 </EntityLayout.Route>;
 ```
 
-6. Add a new sidebar item in [Root.tsx](https://github.com/backstage/backstage/blob/master/packages/app/src/components/Root/Root.tsx)
+6. Import `CortexScorecardWidget` and update [EntityPage.tsx](https://github.com/backstage/backstage/blob/master/packages/app/src/components/catalog/EntityPage.tsx) to add a new component widget for Cortex:
+
+```tsx
+import { CortexScorecardWidget } from '@cortexapps/backstage-plugin';
+
+<Grid item md={4} xs={12}>
+  <CortexScorecardWidget />
+</Grid>
+```
+
+7. Add a new sidebar item in [Root.tsx](https://github.com/backstage/backstage/blob/master/packages/app/src/components/Root/Root.tsx)
 
 ```tsx
 import { CortexIcon } from '@cortexapps/backstage-plugin';

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ import { EntityCortexContent } from '@cortexapps/backstage-plugin';
 </EntityLayout.Route>;
 ```
 
-6. Import `CortexScorecardWidget` and update [EntityPage.tsx](https://github.com/backstage/backstage/blob/master/packages/app/src/components/catalog/EntityPage.tsx) to add a new component widget for Cortex:
+6. (Optional) Import `CortexScorecardWidget` and update [EntityPage.tsx](https://github.com/backstage/backstage/blob/master/packages/app/src/components/catalog/EntityPage.tsx) to add a new component widget for Cortex:
 
 ```tsx
 import { CortexScorecardWidget } from '@cortexapps/backstage-plugin';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/CortexScorecardWidget/CortexScorecardWidget.test.tsx
+++ b/src/components/CortexScorecardWidget/CortexScorecardWidget.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { CortexApi } from '../../api/CortexApi';
+import { render } from '@testing-library/react';
+import { TestApiProvider, wrapInTestApp } from '@backstage/test-utils';
+import { cortexApiRef } from '../../api';
+import { rootRouteRef } from '../../routes';
+import { CortexScorecardWidget } from './CortexScorecardWidget';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+
+describe('<CortexScorecardWidget />', () => {
+  const entity = {
+    apiVersion: 'v1',
+    kind: 'Component',
+    metadata: {
+      name: 'ExampleComponent',
+      annotations: {
+        'github.com/project-slug': 'example/project',
+      },
+    },
+    spec: {
+      owner: 'guest',
+      type: 'service',
+      lifecycle: 'production',
+    },
+  };
+
+  const cortexApi: Partial<CortexApi> = {
+    getServiceScores: () =>
+      Promise.resolve([
+        {
+          score: { scorePercentage: 0.42, score: 42, totalPossibleScore: 100 },
+          scorecard: { id: 1, name: 'My Scorecard', description: 'test' },
+          evaluation: { rules: [], ladderLevels: [] },
+        },
+      ]),
+  };
+
+  const renderWrapped = (children: React.ReactNode) =>
+    render(
+      wrapInTestApp(
+        <TestApiProvider apis={[[cortexApiRef, cortexApi]]}>
+          <EntityProvider entity={entity}>{children}</EntityProvider>
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/': rootRouteRef as any,
+          },
+        },
+      ),
+    );
+
+  it('test', async () => {
+    const { findByText } = renderWrapped(<CortexScorecardWidget />);
+    expect(await findByText(/42%/)).toBeInTheDocument();
+    expect(await findByText(/My Scorecard/)).toBeInTheDocument();
+  });
+});

--- a/src/components/CortexScorecardWidget/CortexScorecardWidget.tsx
+++ b/src/components/CortexScorecardWidget/CortexScorecardWidget.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from "react";
+import {useCortexApi} from "../../utils/hooks";
+import {stringifyAnyEntityRef} from "../../utils/types";
+import {useEntityFromUrl} from "@backstage/plugin-catalog-react";
+import {EntityScorecardsCard} from "../EntityPage/EntityScorecardsCard";
+
+export const CortexScorecardWidget = () => {
+    const {
+        entity,
+        loading: entityLoading,
+        error: entityError,
+    } = useEntityFromUrl();
+
+    const {
+        value: scores,
+        loading: scoresLoading,
+        error: scoresError,
+    } = useCortexApi(
+      async cortexApi => {
+          return entity !== undefined
+            ? await cortexApi.getServiceScores(stringifyAnyEntityRef(entity))
+            : undefined;
+      },
+      [entity],
+    );
+
+    return (
+      <EntityScorecardsCard
+        entityLoading={entityLoading}
+        scoresLoading={scoresLoading}
+        entity={entity}
+        entityError={entityError}
+        scoresError={scoresError}
+        scores={scores}
+        onSelect={() => {}}
+      />
+    );
+}

--- a/src/components/CortexScorecardWidget/CortexScorecardWidget.tsx
+++ b/src/components/CortexScorecardWidget/CortexScorecardWidget.tsx
@@ -18,6 +18,7 @@ import { useCortexApi } from '../../utils/hooks';
 import { stringifyAnyEntityRef } from '../../utils/types';
 import { useEntityFromUrl } from '@backstage/plugin-catalog-react';
 import { EntityScorecardsCard } from '../EntityPage/EntityScorecardsCard';
+import { EmptyState, Progress, WarningPanel } from '@backstage/core-components';
 
 export const CortexScorecardWidget = () => {
   const {
@@ -39,13 +40,39 @@ export const CortexScorecardWidget = () => {
     [entity],
   );
 
+  if (entityLoading || scoresLoading) {
+    return <Progress />;
+  }
+
+  if (entity === undefined || entityError) {
+    return (
+      <WarningPanel severity="error" title="Could not load entity.">
+        {entityError?.message}
+      </WarningPanel>
+    );
+  }
+
+  if (scoresError || scores === undefined) {
+    return (
+      <WarningPanel severity="error" title="Could not load scorecards.">
+        {scoresError?.message}
+      </WarningPanel>
+    );
+  }
+
+  if (scores.length === 0) {
+    return (
+      <EmptyState
+        missing="info"
+        title="No scorecards to display"
+        description="You haven't added any scorecards yet."
+      />
+    );
+  }
+
   return (
     <EntityScorecardsCard
-      entityLoading={entityLoading}
-      scoresLoading={scoresLoading}
-      entity={entity}
-      entityError={entityError}
-      scoresError={scoresError}
+      componentRef={stringifyAnyEntityRef(entity)}
       scores={scores}
       onSelect={() => {}}
     />

--- a/src/components/CortexScorecardWidget/CortexScorecardWidget.tsx
+++ b/src/components/CortexScorecardWidget/CortexScorecardWidget.tsx
@@ -16,16 +16,12 @@
 import React from 'react';
 import { useCortexApi } from '../../utils/hooks';
 import { stringifyAnyEntityRef } from '../../utils/types';
-import { useEntityFromUrl } from '@backstage/plugin-catalog-react';
+import { useEntity } from '@backstage/plugin-catalog-react';
 import { EntityScorecardsCard } from '../EntityPage/EntityScorecardsCard';
 import { EmptyState, Progress, WarningPanel } from '@backstage/core-components';
 
 export const CortexScorecardWidget = () => {
-  const {
-    entity,
-    loading: entityLoading,
-    error: entityError,
-  } = useEntityFromUrl();
+  const { entity, loading: entityLoading, error: entityError } = useEntity();
 
   const {
     value: scores,

--- a/src/components/CortexScorecardWidget/CortexScorecardWidget.tsx
+++ b/src/components/CortexScorecardWidget/CortexScorecardWidget.tsx
@@ -13,41 +13,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from "react";
-import {useCortexApi} from "../../utils/hooks";
-import {stringifyAnyEntityRef} from "../../utils/types";
-import {useEntityFromUrl} from "@backstage/plugin-catalog-react";
-import {EntityScorecardsCard} from "../EntityPage/EntityScorecardsCard";
+import React from 'react';
+import { useCortexApi } from '../../utils/hooks';
+import { stringifyAnyEntityRef } from '../../utils/types';
+import { useEntityFromUrl } from '@backstage/plugin-catalog-react';
+import { EntityScorecardsCard } from '../EntityPage/EntityScorecardsCard';
 
 export const CortexScorecardWidget = () => {
-    const {
-        entity,
-        loading: entityLoading,
-        error: entityError,
-    } = useEntityFromUrl();
+  const {
+    entity,
+    loading: entityLoading,
+    error: entityError,
+  } = useEntityFromUrl();
 
-    const {
-        value: scores,
-        loading: scoresLoading,
-        error: scoresError,
-    } = useCortexApi(
-      async cortexApi => {
-          return entity !== undefined
-            ? await cortexApi.getServiceScores(stringifyAnyEntityRef(entity))
-            : undefined;
-      },
-      [entity],
-    );
+  const {
+    value: scores,
+    loading: scoresLoading,
+    error: scoresError,
+  } = useCortexApi(
+    async cortexApi => {
+      return entity !== undefined
+        ? await cortexApi.getServiceScores(stringifyAnyEntityRef(entity))
+        : undefined;
+    },
+    [entity],
+  );
 
-    return (
-      <EntityScorecardsCard
-        entityLoading={entityLoading}
-        scoresLoading={scoresLoading}
-        entity={entity}
-        entityError={entityError}
-        scoresError={scoresError}
-        scores={scores}
-        onSelect={() => {}}
-      />
-    );
-}
+  return (
+    <EntityScorecardsCard
+      entityLoading={entityLoading}
+      scoresLoading={scoresLoading}
+      entity={entity}
+      entityError={entityError}
+      scoresError={scoresError}
+      scores={scores}
+      onSelect={() => {}}
+    />
+  );
+};

--- a/src/components/CortexScorecardWidget/index.ts
+++ b/src/components/CortexScorecardWidget/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { CortexScorecardWidget } from './CortexScorecardWidget';

--- a/src/components/EntityPage/EntityPage.tsx
+++ b/src/components/EntityPage/EntityPage.tsx
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 import React, { useEffect, useMemo, useState } from 'react';
-import {
-  Content,
-} from '@backstage/core-components';
+import { Content } from '@backstage/core-components';
 import { Grid } from '@material-ui/core';
 import { EntityScorecardsCard } from './EntityScorecardsCard';
 import { useEntityFromUrl } from '@backstage/plugin-catalog-react';

--- a/src/components/EntityPage/EntityPage.tsx
+++ b/src/components/EntityPage/EntityPage.tsx
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 import React, { useEffect, useMemo, useState } from 'react';
-import { Content } from '@backstage/core-components';
+import {
+  Content,
+  EmptyState,
+  Progress,
+  WarningPanel,
+} from '@backstage/core-components';
 import { Grid } from '@material-ui/core';
 import { EntityScorecardsCard } from './EntityScorecardsCard';
 import { useEntityFromUrl } from '@backstage/plugin-catalog-react';
@@ -57,17 +62,32 @@ export const EntityPage = () => {
     return scores?.find(score => score.scorecard.id === selectedScorecardId);
   }, [scores, selectedScorecardId]);
 
-  if (selectedScore === undefined) {
+  if (entityLoading || scoresLoading) {
+    return <Progress />;
+  }
+
+  if (entity === undefined || entityError) {
     return (
-      <EntityScorecardsCard
-        entityLoading={entityLoading}
-        scoresLoading={scoresLoading}
-        entity={entity}
-        entityError={entityError}
-        scoresError={scoresError}
-        scores={scores}
-        onSelect={setSelectedScorecardId}
-        selectedScorecardId={selectedScorecardId}
+      <WarningPanel severity="error" title="Could not load entity.">
+        {entityError?.message}
+      </WarningPanel>
+    );
+  }
+
+  if (scoresError || scores === undefined) {
+    return (
+      <WarningPanel severity="error" title="Could not load scorecards.">
+        {scoresError?.message}
+      </WarningPanel>
+    );
+  }
+
+  if (scores.length === 0) {
+    return (
+      <EmptyState
+        missing="info"
+        title="No scorecards to display"
+        description="You haven't added any scorecards yet."
       />
     );
   }
@@ -77,11 +97,7 @@ export const EntityPage = () => {
       <Grid container direction="row" spacing={2}>
         <Grid item lg={4}>
           <EntityScorecardsCard
-            entityLoading={entityLoading}
-            scoresLoading={scoresLoading}
-            entity={entity}
-            entityError={entityError}
-            scoresError={scoresError}
+            componentRef={stringifyAnyEntityRef(entity)}
             scores={scores}
             onSelect={setSelectedScorecardId}
             selectedScorecardId={selectedScorecardId}

--- a/src/components/EntityPage/EntityPage.tsx
+++ b/src/components/EntityPage/EntityPage.tsx
@@ -16,9 +16,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   Content,
-  EmptyState,
-  Progress,
-  WarningPanel,
 } from '@backstage/core-components';
 import { Grid } from '@material-ui/core';
 import { EntityScorecardsCard } from './EntityScorecardsCard';
@@ -62,32 +59,17 @@ export const EntityPage = () => {
     return scores?.find(score => score.scorecard.id === selectedScorecardId);
   }, [scores, selectedScorecardId]);
 
-  if (entityLoading || scoresLoading) {
-    return <Progress />;
-  }
-
-  if (entity === undefined || entityError) {
+  if (selectedScore === undefined) {
     return (
-      <WarningPanel severity="error" title="Could not load entity.">
-        {entityError?.message}
-      </WarningPanel>
-    );
-  }
-
-  if (scoresError || scores === undefined) {
-    return (
-      <WarningPanel severity="error" title="Could not load scorecards.">
-        {scoresError?.message}
-      </WarningPanel>
-    );
-  }
-
-  if (scores.length === 0) {
-    return (
-      <EmptyState
-        missing="info"
-        title="No scorecards to display"
-        description="You haven't added any scorecards yet."
+      <EntityScorecardsCard
+        entityLoading={entityLoading}
+        scoresLoading={scoresLoading}
+        entity={entity}
+        entityError={entityError}
+        scoresError={scoresError}
+        scores={scores}
+        onSelect={setSelectedScorecardId}
+        selectedScorecardId={selectedScorecardId}
       />
     );
   }
@@ -97,6 +79,11 @@ export const EntityPage = () => {
       <Grid container direction="row" spacing={2}>
         <Grid item lg={4}>
           <EntityScorecardsCard
+            entityLoading={entityLoading}
+            scoresLoading={scoresLoading}
+            entity={entity}
+            entityError={entityError}
+            scoresError={scoresError}
             scores={scores}
             onSelect={setSelectedScorecardId}
             selectedScorecardId={selectedScorecardId}

--- a/src/components/EntityPage/EntityScorecardsCard.tsx
+++ b/src/components/EntityPage/EntityScorecardsCard.tsx
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 import React from 'react';
-import {EmptyState, InfoCard, Progress, WarningPanel} from '@backstage/core-components';
+import {
+  EmptyState,
+  InfoCard,
+  Progress,
+  WarningPanel,
+} from '@backstage/core-components';
 import { makeStyles, Table, TableBody } from '@material-ui/core';
 import { EntityScorecardsCardRow } from './EntityScorecardsCardRow';
 import { BackstageTheme } from '@backstage/theme';
 import { ServiceScorecardScore } from '../../api/types';
-import {Entity} from "@backstage/catalog-model";
-import {stringifyAnyEntityRef} from "../../utils/types";
+import { Entity } from '@backstage/catalog-model';
+import { stringifyAnyEntityRef } from '../../utils/types';
 
 const useStyles = makeStyles<BackstageTheme>(theme => ({
   table: {

--- a/src/components/EntityPage/EntityScorecardsCard.tsx
+++ b/src/components/EntityPage/EntityScorecardsCard.tsx
@@ -14,18 +14,11 @@
  * limitations under the License.
  */
 import React from 'react';
-import {
-  EmptyState,
-  InfoCard,
-  Progress,
-  WarningPanel,
-} from '@backstage/core-components';
+import { InfoCard } from '@backstage/core-components';
 import { makeStyles, Table, TableBody } from '@material-ui/core';
 import { EntityScorecardsCardRow } from './EntityScorecardsCardRow';
 import { BackstageTheme } from '@backstage/theme';
 import { ServiceScorecardScore } from '../../api/types';
-import { Entity } from '@backstage/catalog-model';
-import { stringifyAnyEntityRef } from '../../utils/types';
 
 const useStyles = makeStyles<BackstageTheme>(theme => ({
   table: {
@@ -39,57 +32,19 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
 }));
 
 interface EntityScorecardsCardProps {
-  entityLoading: boolean;
-  scoresLoading: boolean;
-  entity: Entity | undefined;
-  entityError: Error | undefined;
-  scoresError: Error | undefined;
-  scores: ServiceScorecardScore[] | undefined;
+  componentRef: string;
+  scores: ServiceScorecardScore[];
   selectedScorecardId?: number;
   onSelect: (scorecardId: number) => void;
 }
 
 export const EntityScorecardsCard = ({
-  entityLoading,
-  scoresLoading,
-  entity,
-  entityError,
-  scoresError,
+  componentRef,
   scores,
   selectedScorecardId,
   onSelect,
 }: EntityScorecardsCardProps) => {
   const classes = useStyles();
-
-  if (entityLoading || scoresLoading) {
-    return <Progress />;
-  }
-
-  if (entity === undefined || entityError) {
-    return (
-      <WarningPanel severity="error" title="Could not load entity.">
-        {entityError?.message}
-      </WarningPanel>
-    );
-  }
-
-  if (scoresError || scores === undefined) {
-    return (
-      <WarningPanel severity="error" title="Could not load scorecards.">
-        {scoresError?.message}
-      </WarningPanel>
-    );
-  }
-
-  if (scores.length === 0) {
-    return (
-      <EmptyState
-        missing="info"
-        title="No scorecards to display"
-        description="You haven't added any scorecards yet."
-      />
-    );
-  }
 
   return (
     <InfoCard title="Scorecards">
@@ -97,7 +52,7 @@ export const EntityScorecardsCard = ({
         <TableBody>
           {scores.map(score => (
             <EntityScorecardsCardRow
-              componentRef={stringifyAnyEntityRef(entity)}
+              componentRef={componentRef}
               key={score.scorecard.id}
               score={score}
               onSelect={() => onSelect(score.scorecard.id)}

--- a/src/components/EntityPage/EntityScorecardsCard.tsx
+++ b/src/components/EntityPage/EntityScorecardsCard.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 import React from 'react';
-import { InfoCard } from '@backstage/core-components';
+import {EmptyState, InfoCard, Progress, WarningPanel} from '@backstage/core-components';
 import { makeStyles, Table, TableBody } from '@material-ui/core';
 import { EntityScorecardsCardRow } from './EntityScorecardsCardRow';
 import { BackstageTheme } from '@backstage/theme';
 import { ServiceScorecardScore } from '../../api/types';
+import {Entity} from "@backstage/catalog-model";
+import {stringifyAnyEntityRef} from "../../utils/types";
 
 const useStyles = makeStyles<BackstageTheme>(theme => ({
   table: {
@@ -32,17 +34,57 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
 }));
 
 interface EntityScorecardsCardProps {
-  scores: ServiceScorecardScore[];
+  entityLoading: boolean;
+  scoresLoading: boolean;
+  entity: Entity | undefined;
+  entityError: Error | undefined;
+  scoresError: Error | undefined;
+  scores: ServiceScorecardScore[] | undefined;
   selectedScorecardId?: number;
   onSelect: (scorecardId: number) => void;
 }
 
 export const EntityScorecardsCard = ({
+  entityLoading,
+  scoresLoading,
+  entity,
+  entityError,
+  scoresError,
   scores,
   selectedScorecardId,
   onSelect,
 }: EntityScorecardsCardProps) => {
   const classes = useStyles();
+
+  if (entityLoading || scoresLoading) {
+    return <Progress />;
+  }
+
+  if (entity === undefined || entityError) {
+    return (
+      <WarningPanel severity="error" title="Could not load entity.">
+        {entityError?.message}
+      </WarningPanel>
+    );
+  }
+
+  if (scoresError || scores === undefined) {
+    return (
+      <WarningPanel severity="error" title="Could not load scorecards.">
+        {scoresError?.message}
+      </WarningPanel>
+    );
+  }
+
+  if (scores.length === 0) {
+    return (
+      <EmptyState
+        missing="info"
+        title="No scorecards to display"
+        description="You haven't added any scorecards yet."
+      />
+    );
+  }
 
   return (
     <InfoCard title="Scorecards">
@@ -50,6 +92,7 @@ export const EntityScorecardsCard = ({
         <TableBody>
           {scores.map(score => (
             <EntityScorecardsCardRow
+              componentRef={stringifyAnyEntityRef(entity)}
               key={score.scorecard.id}
               score={score}
               onSelect={() => onSelect(score.scorecard.id)}

--- a/src/components/EntityPage/EntityScorecardsCardRow.tsx
+++ b/src/components/EntityPage/EntityScorecardsCardRow.tsx
@@ -18,8 +18,8 @@ import { ServiceScorecardScore } from '../../api/types';
 import { makeStyles, TableCell, TableRow } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import { Gauge } from '../Gauge';
-import { ScorecardRefLink } from '../ScorecardRefLink';
 import { BackstageTheme } from '@backstage/theme';
+import {ScorecardServiceRefLink} from "../ScorecardServiceRefLink";
 
 const useStyles = makeStyles<BackstageTheme, EntityScorecardsCardRowProps>(
   theme => ({
@@ -38,6 +38,7 @@ const useStyles = makeStyles<BackstageTheme, EntityScorecardsCardRowProps>(
 );
 
 interface EntityScorecardsCardRowProps {
+  componentRef: string;
   score: ServiceScorecardScore;
   selected: boolean;
   onSelect: () => void;
@@ -46,7 +47,7 @@ interface EntityScorecardsCardRowProps {
 export const EntityScorecardsCardRow = (
   props: EntityScorecardsCardRowProps,
 ) => {
-  const { score, onSelect } = props;
+  const { componentRef, score, onSelect } = props;
   const classes = useStyles(props);
 
   return (
@@ -72,9 +73,9 @@ export const EntityScorecardsCardRow = (
               />
             </Box>
             <Box alignSelf="center">
-              <ScorecardRefLink scorecardId={score.scorecard.id}>
+              <ScorecardServiceRefLink scorecardId={score.scorecard.id} componentRef={componentRef}>
                 <b>{score.scorecard.name}</b>
-              </ScorecardRefLink>
+              </ScorecardServiceRefLink>
             </Box>
           </Box>
         </TableCell>

--- a/src/components/EntityPage/EntityScorecardsCardRow.tsx
+++ b/src/components/EntityPage/EntityScorecardsCardRow.tsx
@@ -19,7 +19,7 @@ import { makeStyles, TableCell, TableRow } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import { Gauge } from '../Gauge';
 import { BackstageTheme } from '@backstage/theme';
-import {ScorecardServiceRefLink} from "../ScorecardServiceRefLink";
+import { ScorecardServiceRefLink } from '../ScorecardServiceRefLink';
 
 const useStyles = makeStyles<BackstageTheme, EntityScorecardsCardRowProps>(
   theme => ({
@@ -73,7 +73,10 @@ export const EntityScorecardsCardRow = (
               />
             </Box>
             <Box alignSelf="center">
-              <ScorecardServiceRefLink scorecardId={score.scorecard.id} componentRef={componentRef}>
+              <ScorecardServiceRefLink
+                scorecardId={score.scorecard.id}
+                componentRef={componentRef}
+              >
                 <b>{score.scorecard.name}</b>
               </ScorecardServiceRefLink>
             </Box>

--- a/src/components/ScorecardServiceRefLink/ScorecardServiceRefLink.tsx
+++ b/src/components/ScorecardServiceRefLink/ScorecardServiceRefLink.tsx
@@ -15,10 +15,10 @@
  */
 import React from 'react';
 import { useRouteRef } from '@backstage/core-plugin-api';
-import {scorecardServiceDetailsRouteRef} from '../../routes';
+import { scorecardServiceDetailsRouteRef } from '../../routes';
 import { Link } from '@backstage/core-components';
-import {parseEntityName} from "@backstage/catalog-model";
-import {defaultComponentRefContext} from "../../utils/ComponentUtils";
+import { parseEntityName } from '@backstage/catalog-model';
+import { defaultComponentRefContext } from '../../utils/ComponentUtils';
 
 interface ScorecardRefLinkProps {
   scorecardId: number;
@@ -31,12 +31,20 @@ export const ScorecardServiceRefLink = ({
   scorecardId,
   children,
 }: ScorecardRefLinkProps) => {
-  const scorecardServiceDetailsRef = useRouteRef(scorecardServiceDetailsRouteRef);
-
-  const entityName = parseEntityName(
-    componentRef,
-    defaultComponentRefContext,
+  const scorecardServiceDetailsRef = useRouteRef(
+    scorecardServiceDetailsRouteRef,
   );
 
-  return <Link to={scorecardServiceDetailsRef({scorecardId: `${scorecardId}`, ...entityName })}>{children}</Link>;
+  const entityName = parseEntityName(componentRef, defaultComponentRefContext);
+
+  return (
+    <Link
+      to={scorecardServiceDetailsRef({
+        scorecardId: `${scorecardId}`,
+        ...entityName,
+      })}
+    >
+      {children}
+    </Link>
+  );
 };

--- a/src/components/ScorecardServiceRefLink/ScorecardServiceRefLink.tsx
+++ b/src/components/ScorecardServiceRefLink/ScorecardServiceRefLink.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { useRouteRef } from '@backstage/core-plugin-api';
+import {scorecardServiceDetailsRouteRef} from '../../routes';
+import { Link } from '@backstage/core-components';
+import {parseEntityName} from "@backstage/catalog-model";
+import {defaultComponentRefContext} from "../../utils/ComponentUtils";
+
+interface ScorecardRefLinkProps {
+  scorecardId: number;
+  children?: React.ReactNode;
+  componentRef: string;
+}
+
+export const ScorecardServiceRefLink = ({
+  componentRef,
+  scorecardId,
+  children,
+}: ScorecardRefLinkProps) => {
+  const scorecardServiceDetailsRef = useRouteRef(scorecardServiceDetailsRouteRef);
+
+  const entityName = parseEntityName(
+    componentRef,
+    defaultComponentRefContext,
+  );
+
+  return <Link to={scorecardServiceDetailsRef({scorecardId: `${scorecardId}`, ...entityName })}>{children}</Link>;
+};

--- a/src/components/ScorecardServiceRefLink/index.ts
+++ b/src/components/ScorecardServiceRefLink/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { ScorecardServiceRefLink } from './ScorecardServiceRefLink';

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableRow.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableRow.tsx
@@ -26,13 +26,10 @@ import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 import Box from '@material-ui/core/Box';
 import { ScorecardResultDetails } from './ScorecardResultDetails';
-import { parseEntityName, parseEntityRef } from '@backstage/catalog-model';
+import { parseEntityRef } from '@backstage/catalog-model';
 import { Gauge } from '../../../Gauge';
-import { Link } from '@backstage/core-components';
-import { useRouteRef } from '@backstage/core-plugin-api';
 import LoyaltyIcon from '@material-ui/icons/Loyalty';
-import { scorecardServiceDetailsRouteRef } from '../../../../routes';
-import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
+import {ScorecardServiceRefLink} from "../../../ScorecardServiceRefLink";
 
 const useStyles = makeStyles({
   root: {
@@ -60,13 +57,7 @@ export const ScorecardsTableRow = ({
   score,
 }: ScorecardsTableRowProps) => {
   const classes = useStyles();
-  const serviceDetailsRef = useRouteRef(scorecardServiceDetailsRouteRef);
   const currentLevel = score.ladderLevels?.[0]?.currentLevel;
-
-  const entityName = parseEntityName(
-    score.componentRef,
-    defaultComponentRefContext,
-  );
 
   const [open, setOpen] = useState(false);
 
@@ -93,12 +84,7 @@ export const ScorecardsTableRow = ({
               />
             </Box>
             <Box alignSelf="center" flex="1">
-              <Link
-                to={serviceDetailsRef({
-                  scorecardId: `${scorecardId}`,
-                  ...entityName,
-                })}
-              >
+              <ScorecardServiceRefLink scorecardId={scorecardId} componentRef={score.componentRef}>
                 <b>
                   {
                     parseEntityRef(score.componentRef, {
@@ -107,7 +93,7 @@ export const ScorecardsTableRow = ({
                     }).name
                   }
                 </b>
-              </Link>
+              </ScorecardServiceRefLink>
             </Box>
             {currentLevel && (
               <Box display="flex" alignItems="center">

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableRow.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableRow.tsx
@@ -29,7 +29,7 @@ import { ScorecardResultDetails } from './ScorecardResultDetails';
 import { parseEntityRef } from '@backstage/catalog-model';
 import { Gauge } from '../../../Gauge';
 import LoyaltyIcon from '@material-ui/icons/Loyalty';
-import {ScorecardServiceRefLink} from "../../../ScorecardServiceRefLink";
+import { ScorecardServiceRefLink } from '../../../ScorecardServiceRefLink';
 
 const useStyles = makeStyles({
   root: {
@@ -84,7 +84,10 @@ export const ScorecardsTableRow = ({
               />
             </Box>
             <Box alignSelf="center" flex="1">
-              <ScorecardServiceRefLink scorecardId={scorecardId} componentRef={score.componentRef}>
+              <ScorecardServiceRefLink
+                scorecardId={scorecardId}
+                componentRef={score.componentRef}
+              >
                 <b>
                   {
                     parseEntityRef(score.componentRef, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { IconComponent } from '@backstage/core-plugin-api';
 export {
   cortexPlugin,
   CortexPage,
+  CortexScorecardWidget,
   EntityCortexContent,
   SystemCortexContent,
   extendableCortexPlugin,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -79,7 +79,7 @@ export const extendableCortexPlugin = <
 
   const CortexPage = plugin.provide(
     createRoutableExtension({
-      name: "CortexPage",
+      name: 'CortexPage',
       component: () =>
         import('./components/CortexPage').then(m => m.CortexPage),
       mountPoint: rootRouteRef,
@@ -88,7 +88,7 @@ export const extendableCortexPlugin = <
 
   const EntityCortexContent = plugin.provide(
     createComponentExtension({
-      name: "EntityCortexContent",
+      name: 'EntityCortexContent',
       component: {
         lazy: () => import('./components/EntityPage').then(m => m.EntityPage),
       },
@@ -97,9 +97,10 @@ export const extendableCortexPlugin = <
 
   const SystemCortexContent = plugin.provide(
     createComponentExtension({
-      name: "SystemCortexContent",
+      name: 'SystemCortexContent',
       component: {
-        lazy: () => import('./components/SystemPage/SystemPage').then(m => m.SystemPage),
+        lazy: () =>
+          import('./components/SystemPage/SystemPage').then(m => m.SystemPage),
       },
     }),
   );
@@ -109,7 +110,7 @@ export const extendableCortexPlugin = <
 
 export const CortexPage = cortexPlugin.provide(
   createRoutableExtension({
-    name: "CortexPage",
+    name: 'CortexPage',
     component: () => import('./components/CortexPage').then(m => m.CortexPage),
     mountPoint: rootRouteRef,
   }),
@@ -117,16 +118,19 @@ export const CortexPage = cortexPlugin.provide(
 
 export const CortexScorecardWidget = cortexPlugin.provide(
   createComponentExtension({
-    name: "CortexScorecardWidget",
+    name: 'CortexScorecardWidget',
     component: {
-      lazy: () => import('./components/CortexScorecardWidget').then(m => m.CortexScorecardWidget),
+      lazy: () =>
+        import('./components/CortexScorecardWidget').then(
+          m => m.CortexScorecardWidget,
+        ),
     },
   }),
 );
 
 export const EntityCortexContent = cortexPlugin.provide(
   createComponentExtension({
-    name: "EntityCortexContent",
+    name: 'EntityCortexContent',
     component: {
       lazy: () => import('./components/EntityPage').then(m => m.EntityPage),
     },
@@ -135,9 +139,10 @@ export const EntityCortexContent = cortexPlugin.provide(
 
 export const SystemCortexContent = cortexPlugin.provide(
   createComponentExtension({
-    name: "SystemCortexContent",
+    name: 'SystemCortexContent',
     component: {
-      lazy: () => import('./components/SystemPage/SystemPage').then(m => m.SystemPage),
+      lazy: () =>
+        import('./components/SystemPage/SystemPage').then(m => m.SystemPage),
     },
   }),
 );

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -115,6 +115,15 @@ export const CortexPage = cortexPlugin.provide(
   }),
 );
 
+export const CortexScorecardWidget = cortexPlugin.provide(
+  createComponentExtension({
+    name: "CortexScorecardWidget",
+    component: {
+      lazy: () => import('./components/CortexScorecardWidget').then(m => m.CortexScorecardWidget),
+    },
+  }),
+);
+
 export const EntityCortexContent = cortexPlugin.provide(
   createComponentExtension({
     name: "EntityCortexContent",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -95,6 +95,18 @@ export const extendableCortexPlugin = <
     }),
   );
 
+  const CortexScorecardWidget = plugin.provide(
+    createComponentExtension({
+      name: 'CortexScorecardWidget',
+      component: {
+        lazy: () =>
+          import('./components/CortexScorecardWidget').then(
+            m => m.CortexScorecardWidget,
+          ),
+      },
+    }),
+  );
+
   const SystemCortexContent = plugin.provide(
     createComponentExtension({
       name: 'SystemCortexContent',
@@ -105,7 +117,13 @@ export const extendableCortexPlugin = <
     }),
   );
 
-  return { plugin, CortexPage, EntityCortexContent, SystemCortexContent };
+  return {
+    plugin,
+    CortexPage,
+    EntityCortexContent,
+    CortexScorecardWidget,
+    SystemCortexContent,
+  };
 };
 
 export const CortexPage = cortexPlugin.provide(


### PR DESCRIPTION
## Change description

Backstage component widget that shows an overview of scorecards for a service component and the service's scores. Clicking on a scorecard takes you to that service's detailed scorecard page.

The links for the scorecards in a service component's Cortex catalog tab have also been updated to take you to that service's detailed scorecard page instead of the overall scorecard page.
![image](https://user-images.githubusercontent.com/12239257/153553543-42731dc9-7983-4468-bf6c-a818340badad.png)

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
