### PR TITLE
CET-483 show failure messages for rules in scorecard section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/RuleResultDetails.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/RuleResultDetails.tsx
@@ -78,6 +78,13 @@ export const RuleResultDetails = ({
             </Typography>
           </Grid>
         )}
+        {rule.rule.failureMessage && (
+          <Grid item xs={9}>
+            <Typography color="error" style={{ wordWrap: 'break-word' }}>
+              {rule.rule.failureMessage}
+            </Typography>
+          </Grid>
+        )}
       </Grid>
     </ListItem>
   );

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/RuleResultDetails.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/RuleResultDetails.tsx
@@ -78,7 +78,7 @@ export const RuleResultDetails = ({
             </Typography>
           </Grid>
         )}
-        {rule.rule.failureMessage && (
+        {rule.score === 0 && rule.rule.failureMessage && (
           <Grid item xs={9}>
             <Typography color="error" style={{ wordWrap: 'break-word' }}>
               {rule.rule.failureMessage}

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/RuleResultDetails.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/RuleResultDetails.tsx
@@ -25,6 +25,7 @@ import {
 } from '@material-ui/core';
 import ErrorIcon from '@material-ui/icons/Error';
 import CheckIcon from '@material-ui/icons/Check';
+
 import { ScorecardServiceScoreRuleName } from './ScorecardResultDetails';
 
 const useStyles = makeStyles({
@@ -43,11 +44,12 @@ export const RuleResultDetails = ({
   hideWeight,
 }: RuleResultDetailsProps) => {
   const classes = useStyles();
-
+  const isFailing = rule.score === 0;
+  
   return (
     <ListItem alignItems="flex-start">
       <ListItemAvatar>
-        {rule.score > 0 ? (
+        {!isFailing ? (
           <CheckIcon color="primary" />
         ) : (
           <ErrorIcon color="error" />
@@ -78,7 +80,7 @@ export const RuleResultDetails = ({
             </Typography>
           </Grid>
         )}
-        {rule.score === 0 && rule.rule.failureMessage && (
+        {isFailing && rule.rule.failureMessage && (
           <Grid item xs={9}>
             <Typography color="error" style={{ wordWrap: 'break-word' }}>
               {rule.rule.failureMessage}

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardResultDetails.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardResultDetails.tsx
@@ -23,7 +23,7 @@ import {RuleName, ScorecardServiceScoresRule} from "../../../../api/types";
 export type ScorecardServiceScoreRuleName = Omit<
     ScorecardServiceScoresRule,
     'rule'
-    > & { rule: RuleName & { weight: number; } };
+    > & { rule: RuleName & { weight: number; failureMessage?: string } };
 
 interface ScorecardResultDetailsProps {
   rules: ScorecardServiceScoreRuleName[];


### PR DESCRIPTION
## Change description

Show failure messages for rules in scorecard sections in entity
<img width="1743" alt="Screen Shot 2022-02-14 at 19 22 08" src="https://user-images.githubusercontent.com/3963216/153923472-586600bd-1d1f-4609-82ec-f7ac38e0b5cd.png">


## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
