### PR TITLE
have scorecard widget take users to entity page for selected scorecards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/CortexScorecardWidget/CortexScorecardWidget.tsx
+++ b/src/components/CortexScorecardWidget/CortexScorecardWidget.tsx
@@ -19,9 +19,12 @@ import { stringifyAnyEntityRef } from '../../utils/types';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { EntityScorecardsCard } from '../EntityPage/EntityScorecardsCard';
 import { EmptyState, Progress, WarningPanel } from '@backstage/core-components';
+import { useNavigate, useLocation } from 'react-router';
 
 export const CortexScorecardWidget = () => {
   const { entity, loading: entityLoading, error: entityError } = useEntity();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const {
     value: scores,
@@ -66,5 +69,12 @@ export const CortexScorecardWidget = () => {
     );
   }
 
-  return <EntityScorecardsCard scores={scores} onSelect={() => {}} />;
+  return (
+    <EntityScorecardsCard
+      scores={scores}
+      onSelect={scorecardId =>
+        navigate(`${location.pathname}cortex?scorecardId=${scorecardId}`)
+      }
+    />
+  );
 };

--- a/src/components/EntityPage/EntityPage.tsx
+++ b/src/components/EntityPage/EntityPage.tsx
@@ -28,6 +28,7 @@ import { stringifyAnyEntityRef } from '../../utils/types';
 import { useCortexApi } from '../../utils/hooks';
 import { EntityScorecardDetails } from './EntityScorecardDetails';
 import { ScorecardServiceRefLink } from '../ScorecardServiceRefLink';
+import { useLocation } from 'react-router';
 
 export const EntityPage = () => {
   const {
@@ -35,6 +36,11 @@ export const EntityPage = () => {
     loading: entityLoading,
     error: entityError,
   } = useEntityFromUrl();
+
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const queryScorecardId = Number(queryParams.get('scorecardId') ?? undefined);
+
   const [selectedScorecardId, setSelectedScorecardId] = useState<
     number | undefined
   >();
@@ -53,11 +59,11 @@ export const EntityPage = () => {
   );
 
   useEffect(() => {
-    const first = scores?.[0];
-    if (first !== undefined) {
-      setSelectedScorecardId(first.scorecard.id);
+    const scorecardId = queryScorecardId ?? scores?.[0].scorecard.id;
+    if (scorecardId !== undefined) {
+      setSelectedScorecardId(scorecardId);
     }
-  }, [scores, setSelectedScorecardId]);
+  }, [queryScorecardId, scores, setSelectedScorecardId]);
 
   const selectedScore = useMemo(() => {
     return scores?.find(score => score.scorecard.id === selectedScorecardId);

--- a/src/components/ReportsPage/HeatmapPage/HeatmapPage.tsx
+++ b/src/components/ReportsPage/HeatmapPage/HeatmapPage.tsx
@@ -29,7 +29,7 @@ import { isUndefined } from 'lodash';
 
 export const HeatmapPage = () => {
   const location = useLocation();
-  const queryParams = new URLSearchParams(useLocation().search);
+  const queryParams = new URLSearchParams(location.search);
 
   const queryScorecardId = Number(queryParams.get('scorecardId') ?? undefined);
   const initialScorecardId = Number.isNaN(queryScorecardId)


### PR DESCRIPTION
## Change description

ScorecardWidget takes users to the Entity page for selected scorecard: 

![Screen Shot 2022-03-21 at 2 04 42 PM](https://user-images.githubusercontent.com/8764399/159336257-f320f97b-e285-4c21-a1c1-97179c594b79.png)

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
