### PR TITLE
Various backstage updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/EntityPage/EntityScorecardsCardRow.tsx
+++ b/src/components/EntityPage/EntityScorecardsCardRow.tsx
@@ -19,9 +19,11 @@ import { makeStyles, TableCell, TableRow } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import { Gauge } from '../Gauge';
 import { BackstageTheme } from '@backstage/theme';
+import { ScorecardLadderLevelBadge } from '../Common/ScorecardLadderLevelBadge';
 
 const useStyles = makeStyles<BackstageTheme>(theme => ({
   tableRow: {
+    cursor: 'pointer',
     '&:hover': {
       background: `${theme.palette.background.default}!important`,
     },
@@ -46,6 +48,7 @@ export const EntityScorecardsCardRow = ({
   onSelect,
 }: EntityScorecardsCardRowProps) => {
   const classes = useStyles();
+  const currentLevel = score.evaluation.ladderLevels?.[0]?.currentLevel;
 
   return (
     <React.Fragment>
@@ -62,16 +65,20 @@ export const EntityScorecardsCardRow = ({
             justifyContent="flex-start"
             alignItems="center"
           >
-            <Box alignSelf="center" width={1 / 5}>
-              <Gauge
-                value={score.score.scorePercentage}
-                strokeWidth={10}
-                trailWidth={10}
-              />
-            </Box>
             <Box alignSelf="center">
+              <Gauge value={score.score.scorePercentage} />
+            </Box>
+            <Box alignSelf="center" flex="1">
               <b>{score.scorecard.name}</b>
             </Box>
+            {currentLevel && (
+              <Box display="flex" alignItems="center">
+                <ScorecardLadderLevelBadge
+                  name={currentLevel.name}
+                  color={currentLevel.color}
+                />
+              </Box>
+            )}
           </Box>
         </TableCell>
       </TableRow>

--- a/src/components/FilterCard/Filters.tsx
+++ b/src/components/FilterCard/Filters.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import {
   Checkbox,
   Grid,

--- a/src/components/FilterCard/Filters.tsx
+++ b/src/components/FilterCard/Filters.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   Checkbox,
   Grid,

--- a/src/components/Gauge/Gauge.tsx
+++ b/src/components/Gauge/Gauge.tsx
@@ -23,6 +23,7 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
   root: {
     position: 'relative',
     lineHeight: 0,
+    width: '80px',
   },
   overlay: {
     position: 'absolute',

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeFilterCard/InitiativeFilterCard.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeFilterCard/InitiativeFilterCard.tsx
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 import React, { useMemo } from 'react';
-import { Initiative, InitiativeActionItem } from '../../../../api/types';
+import {
+  Initiative,
+  InitiativeActionItem,
+  ruleName,
+} from '../../../../api/types';
 import { FilterCard } from '../../../FilterCard';
 import { mapByString, mapValues } from '../../../../utils/collections';
 import {
@@ -70,7 +74,7 @@ export const InitiativeFilterCard = ({
       mapByString(initiative.emphasizedRules, rule => `${rule.ruleId}`),
       rule => {
         return {
-          display: rule.expression,
+          display: ruleName(rule),
           value: rule.expression,
         };
       },
@@ -90,10 +94,7 @@ export const InitiativeFilterCard = ({
               stringifyAnyEntityRef(entityRef, { defaultKind: 'group' }),
             ),
           formatProperty: (groupRef: string) =>
-            humanizeEntityRef(
-              parseEntityRef(groupRef),
-              defaultGroupRefContext,
-            ),
+            humanizeEntityRef(parseEntityRef(groupRef), defaultGroupRefContext),
         },
         {
           name: 'Systems',

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/FailingComponentsTableRow.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/FailingComponentsTableRow.tsx
@@ -78,7 +78,7 @@ export const FailingComponentsTableRow = ({
             justifyContent="flex-start"
             alignItems="center"
           >
-            <Box alignSelf="center" width={1 / 8}>
+            <Box alignSelf="center">
               <Gauge
                 value={(numRules - actionItems.length) / numRules}
                 textOverride={`${numRules - actionItems.length} / ${numRules}`}

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/PassingComponentsTable.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/PassingComponentsTable.tsx
@@ -66,7 +66,7 @@ export const PassingComponentsTable = ({
                   justifyContent="flex-start"
                   alignItems="center"
                 >
-                  <Box alignSelf="center" width={1 / 8}>
+                  <Box alignSelf="center">
                     <Gauge
                       value={1}
                       textOverride={`${numRules} / ${numRules}`}

--- a/src/components/ReportsPage/HeatmapPage/Tables/HeatmapTableHeader.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/HeatmapTableHeader.tsx
@@ -26,21 +26,26 @@ interface HeatmapTableHeaderProps {
 export const HeatmapTableHeader = ({ headers }: HeatmapTableHeaderProps) => {
   const classes = useHeatmapStyles();
 
-  const cellWidth = 100 / headers.length;
-  const style = { width: `${cellWidth}%` };
+  const cellWidth = 85 / headers.length;
 
   return (
     <TableHead>
       <TableRow>
-        {headers.map((headerText, idx) => (
-          <TableCell
-            key={`HeatmapTableHeader-${idx}`}
-            className={classes.root}
-            style={style}
-          >
-            {headerText}
-          </TableCell>
-        ))}
+        {headers.map((headerText, idx) => {
+          // first column set to 10% so that names don't get squished
+          const style =
+            idx === 0 ? { width: `15%` } : { width: `${cellWidth}%` };
+
+          return (
+            <TableCell
+              key={`HeatmapTableHeader-${idx}`}
+              className={classes.root}
+              style={style}
+            >
+              {headerText}
+            </TableCell>
+          );
+        })}
       </TableRow>
     </TableHead>
   );

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableRow.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableRow.tsx
@@ -17,10 +17,11 @@ import React from 'react';
 import { ScorecardServiceScore } from '../../../../api/types';
 import { makeStyles, TableCell, TableRow } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
-import { parseEntityRef } from '@backstage/catalog-model';
 import { Gauge } from '../../../Gauge';
 import { ScorecardServiceRefLink } from '../../../ScorecardServiceRefLink';
 import { ScorecardLadderLevelBadge } from '../../../Common/ScorecardLadderLevelBadge';
+import { stringifyAnyEntityRef } from '../../../../utils/types';
+import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
 
 const useStyles = makeStyles({
   root: {
@@ -73,12 +74,10 @@ export const ScorecardsTableRow = ({
               </Box>
               <Box alignSelf="center" flex="1">
                 <b>
-                  {
-                    parseEntityRef(score.componentRef, {
-                      defaultKind: 'Component',
-                      defaultNamespace: 'default',
-                    }).name
-                  }
+                  {stringifyAnyEntityRef(
+                    score.componentRef,
+                    defaultComponentRefContext,
+                  )}
                 </b>
               </Box>
               {currentLevel && (

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableRow.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableRow.tsx
@@ -64,7 +64,7 @@ export const ScorecardsTableRow = ({
               justifyContent="flex-start"
               alignItems="center"
             >
-              <Box alignSelf="center" width={1 / 10}>
+              <Box alignSelf="center">
                 <Gauge
                   value={score.scorePercentage}
                   strokeWidth={10}

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
@@ -18,6 +18,7 @@ import { useApi, useRouteRefParams } from '@backstage/core-plugin-api';
 import {
   Content,
   InfoCard,
+  Link,
   Progress,
   WarningPanel,
 } from '@backstage/core-components';
@@ -33,6 +34,7 @@ import { ScorecardsServiceProgress } from './ScorecardsServiceProgress';
 import { entityEquals } from '../../../utils/types';
 import { ScorecardsServiceNextRules } from './ScorecardsServiceNextRules';
 import { ScorecardServiceScoresRule } from '../../../api/types';
+import { cortexScorecardServicePageURL } from '../../../utils/URLUtils';
 
 const useStyles = makeStyles({
   progress: {
@@ -96,17 +98,25 @@ export const ScorecardsServicePage = () => {
         alignItems="center"
         style={{ marginBottom: '20px' }}
       >
-        <Box alignSelf="center" width={1 / 16}>
+        <Box alignSelf="center">
           <Gauge
             value={score.scorePercentage}
             strokeWidth={10}
             trailWidth={10}
           />
         </Box>
-        <Box alignSelf="center" textAlign="center">
+        <Box alignSelf="center" flex="1">
           <Typography variant="h4" component="h2">
             <DefaultEntityRefLink entityRef={entityRef} />
           </Typography>
+        </Box>
+        <Box alignSelf="center">
+          <Link
+            to={cortexScorecardServicePageURL(scorecardId, score.serviceId)}
+            target="_blank"
+          >
+            <b>View in Cortex</b>
+          </Link>
         </Box>
       </Box>
 
@@ -117,7 +127,12 @@ export const ScorecardsServicePage = () => {
           </InfoCard>
         </Grid>
         <Grid item lg={8} xs={12}>
-          {ladder && <ScorecardsServiceNextRules scorecardId={+scorecardId} entityRef={entityRef} />}
+          {ladder && (
+            <ScorecardsServiceNextRules
+              scorecardId={+scorecardId}
+              entityRef={entityRef}
+            />
+          )}
           <InfoCard title="Score Progress" className={classes.progress}>
             <ScorecardsServiceProgress
               scorecardId={scorecardId}

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceProgress.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceProgress.tsx
@@ -28,6 +28,7 @@ import { Point } from '@nivo/line';
 import { getLookbackRange, Lookback } from '../../../utils/lookback';
 import { RuleResult, ScorecardServiceScoresRule } from '../../../api/types';
 import { LookbackDropdown } from '../../ReportsPage/Common/LookbackDropdown';
+import { cortexScorecardPageURL } from '../../../utils/URLUtils';
 
 interface ScorecardsServiceProgressProps {
   scorecardId: string;
@@ -112,7 +113,7 @@ export const ScorecardsServiceProgress = ({
           <Button
             variant="contained"
             color="primary"
-            href={`https://app.getcortexapp.com/admin/scorecards/${scorecardId}`}
+            href={cortexScorecardPageURL(scorecardId)}
           >
             Go to Cortex
           </Button>

--- a/src/components/SystemPage/SystemPage.tsx
+++ b/src/components/SystemPage/SystemPage.tsx
@@ -33,6 +33,7 @@ export const SystemPage = () => {
     api => api.getServiceScorecardScores(GroupByOption.SERVICE_GROUP),
     [GroupByOption.SERVICE_GROUP],
   );
+
   const mySystemScores = useMemo(
     () =>
       serviceGroupScores?.filter(serviceGroupScore => {
@@ -44,6 +45,7 @@ export const SystemPage = () => {
       })?.[0],
     [serviceGroupScores, entity],
   );
+
   const myComponents = useMemo(
     () =>
       entity?.relations
@@ -51,6 +53,7 @@ export const SystemPage = () => {
         .map(({ targetRef }) => parseEntityRef(targetRef).name),
     [entity],
   );
+
   const { value: scorecardScores } = useCortexApi(
     api =>
       mySystemScores?.scores
@@ -62,6 +65,7 @@ export const SystemPage = () => {
         : Promise.resolve([]),
     [mySystemScores],
   );
+
   const data = useMemo(
     () =>
       mySystemScores?.scores.map((score, index) => ({

--- a/src/components/SystemPage/SystemPageRow.tsx
+++ b/src/components/SystemPage/SystemPageRow.tsx
@@ -74,7 +74,7 @@ export const SystemPageRow: React.FC<SystemPageRowProps> = ({
             justifyContent="flex-start"
             alignItems="center"
           >
-            <Box alignSelf="center" width={1 / 10}>
+            <Box alignSelf="center">
               <Gauge
                 value={score?.scorePercentage ?? 0}
                 strokeWidth={10}

--- a/src/components/SystemPage/SystemPageRow.tsx
+++ b/src/components/SystemPage/SystemPageRow.tsx
@@ -46,18 +46,19 @@ const useStyles = makeStyles({
   },
 });
 
-interface Props {
+interface SystemPageRowProps {
   score: ScorecardScore;
   scoresForScorecard: ScorecardServiceScore[];
 }
 
-export const SystemPageRow: React.FC<Props> = ({
+export const SystemPageRow: React.FC<SystemPageRowProps> = ({
   score,
   scoresForScorecard,
 }) => {
   const [open, setOpen] = useState(false);
   const classes = useStyles();
   const name = score?.scorecardName ?? '';
+
   return (
     <React.Fragment>
       <TableRow className={classes.root}>

--- a/src/components/SystemPage/SystemPageRowDetails.tsx
+++ b/src/components/SystemPage/SystemPageRowDetails.tsx
@@ -22,8 +22,9 @@ import { ScorecardServiceScore } from '../../api/types';
 import { DefaultEntityRefLink } from '../DefaultEntityLink';
 import { parseEntityRef } from '@backstage/catalog-model';
 import { defaultComponentRefContext } from '../../utils/ComponentUtils';
+import { ScorecardLadderLevelBadge } from '../Common/ScorecardLadderLevelBadge';
 
-interface Props {
+interface SystemPageRowDetailsProps {
   scoresForScorecard: ScorecardServiceScore[];
 }
 
@@ -40,43 +41,55 @@ const useStyles = makeStyles({
   },
 });
 
-export const SystemPageRowDetails: React.FC<Props> = ({
+export const SystemPageRowDetails: React.FC<SystemPageRowDetailsProps> = ({
   scoresForScorecard,
 }) => {
   const classes = useStyles();
 
   return (
     <Table>
-      {scoresForScorecard.map(score => (
-        <TableRow className={classes.root} key={`TableRow${score.serviceId}`}>
-          <TableCell>
-            <Box
-              flexDirection="row"
-              display="flex"
-              justifyContent="flex-start"
-              alignItems="center"
-            >
-              <Box alignSelf="center" width={1 / 16}>
-                <Gauge
-                  value={score.scorePercentage}
-                  strokeWidth={10}
-                  trailWidth={10}
-                />
-              </Box>
-              <Box alignSelf="center" flex="1">
-                {score && (
-                  <DefaultEntityRefLink
-                    entityRef={parseEntityRef(
-                      score.componentRef,
-                      defaultComponentRefContext,
-                    )}
+      {scoresForScorecard.map(score => {
+        const currentLevel = score.ladderLevels?.[0]?.currentLevel;
+
+        return (
+          <TableRow className={classes.root} key={`TableRow${score.serviceId}`}>
+            <TableCell>
+              <Box
+                flexDirection="row"
+                display="flex"
+                justifyContent="flex-start"
+                alignItems="center"
+              >
+                <Box alignSelf="center">
+                  <Gauge
+                    value={score.scorePercentage}
+                    strokeWidth={10}
+                    trailWidth={10}
                   />
+                </Box>
+                <Box alignSelf="center" flex="1">
+                  {score && (
+                    <DefaultEntityRefLink
+                      entityRef={parseEntityRef(
+                        score.componentRef,
+                        defaultComponentRefContext,
+                      )}
+                    />
+                  )}
+                </Box>
+                {currentLevel && (
+                  <Box display="flex" alignItems="center">
+                    <ScorecardLadderLevelBadge
+                      name={currentLevel.name}
+                      color={currentLevel.color}
+                    />
+                  </Box>
                 )}
               </Box>
-            </Box>
-          </TableCell>
-        </TableRow>
-      ))}
+            </TableCell>
+          </TableRow>
+        );
+      })}
     </Table>
   );
 };

--- a/src/utils/URLUtils.ts
+++ b/src/utils/URLUtils.ts
@@ -23,3 +23,13 @@ export const buildUrl = (
     url: pathname,
     query: queryParamsObj,
   })}`;
+
+const cortexURL = 'https://app.getcortexapp.com/admin/';
+
+export const cortexScorecardPageURL = (scorecardId: string | number) =>
+  `${cortexURL}scorecards/${scorecardId}`;
+
+export const cortexScorecardServicePageURL = (
+  scorecardId: string | number,
+  serviceId: string | number,
+) => `${cortexScorecardPageURL(scorecardId)}?service=${serviceId}`;


### PR DESCRIPTION
## Change description

Multiple updates: 

AllScorecards and Bird's Eye Report tables have 15% width for first column (the column with the names) 

Updated Gauge styling so that it doesn't get squished even when screen is tiny:
![Screen Shot 2022-04-20 at 12 04 21 PM](https://user-images.githubusercontent.com/8764399/164204253-e1174a7f-c4af-4a95-8b31-171e02b6bfd1.png)
![Screen Shot 2022-04-20 at 12 01 24 PM](https://user-images.githubusercontent.com/8764399/164203716-63fb8754-6af3-4301-8a18-9dba2c3d7f20.png)

Added level info throughout to Scorecards Row when ladders exist for the Scorecard (Need to verify Systems page here - I wasn't sure how to get to it):
![Screen Shot 2022-04-20 at 12 00 06 PM](https://user-images.githubusercontent.com/8764399/164203471-71179409-e2e3-404b-99c8-a6274a33d973.png)
![Screen Shot 2022-04-20 at 12 00 35 PM](https://user-images.githubusercontent.com/8764399/164203565-97ed49b9-ce22-470a-b884-bd800ee5fcbc.png)

Use rule names if they exist in Initiatives filters: 
![Screen Shot 2022-04-20 at 12 03 36 PM](https://user-images.githubusercontent.com/8764399/164204123-5dbda07c-9de9-47ec-80f7-0af36b20f711.png)

Link to open in Cortex from Single Scorecard details page (https://cortex1.atlassian.net/browse/CET-724 - Is this where they wanted it?)
![Screen Shot 2022-04-20 at 12 04 48 PM](https://user-images.githubusercontent.com/8764399/164204346-26e19eaa-0467-4231-9307-ed747be2df4e.png)

Handled including component name if not default: https://cortex1.atlassian.net/browse/CET-726

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable

