### PR TITLE
fix: fix level info cell list formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/ReportsPage/HeatmapPage/HeatmapPage.test.tsx
+++ b/src/components/ReportsPage/HeatmapPage/HeatmapPage.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { TestApiProvider, wrapInTestApp } from '@backstage/test-utils';
+import { CortexApi } from '../../../api/CortexApi';
+import { cortexApiRef } from '../../../api';
+import { HeatmapPage } from './HeatmapPage';
+import { rootRouteRef } from '../../../routes';
+
+describe('HeatmapPage', () => {
+  const cortexApi: Partial<CortexApi> = {
+    getScorecards: () =>
+      Promise.resolve([
+        {
+          creator: { name: 'Billy Bob', email: 'billybob@cortex.io' },
+          id: 1,
+          name: 'My Scorecard',
+          description: 'Some description',
+          rules: [],
+          tags: [],
+          excludedTags: [],
+          filterQuery: undefined,
+          nextUpdated: '2021-08-25T04:00:00',
+        },
+      ]),
+  };
+
+  const renderWrapped = (children: React.ReactNode) =>
+    render(
+      wrapInTestApp(
+        <TestApiProvider apis={[[cortexApiRef, cortexApi]]}>
+          {children}
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/': rootRouteRef as any,
+          },
+        },
+      ),
+    );
+
+  it('should render', async () => {
+    const { findByText } = renderWrapped(<HeatmapPage />);
+
+    expect(await findByText(/Bird's Eye/)).toBeVisible();
+    expect(await findByText(/Select a Scorecard/)).toBeVisible();
+  });
+});

--- a/src/components/ReportsPage/HeatmapPage/LevelsInfoCell.tsx
+++ b/src/components/ReportsPage/HeatmapPage/LevelsInfoCell.tsx
@@ -48,15 +48,18 @@ export const LevelsInfoCell = ({ identifier, scores }: LevelsInfoCellProps) => {
           </Typography>
         </AccordionSummary>
         <AccordionDetails style={{ display: 'flex', flexDirection: 'column' }}>
-          {scores?.map(score => (
-            <EntityRefLink
-              key={`LevelService-${identifier}-${score.serviceId}`}
-              entityRef={parseEntityRef(
-                score.componentRef,
-                defaultComponentRefContext,
-              )}
-            />
-          ))}
+          <ul style={{ paddingLeft: 16 }}>
+            {scores?.map(score => (
+              <li key={`LevelService-${identifier}-${score.serviceId}`}>
+                <EntityRefLink
+                  entityRef={parseEntityRef(
+                    score.componentRef,
+                    defaultComponentRefContext,
+                  )}
+                />
+              </li>
+            ))}
+          </ul>
         </AccordionDetails>
       </Accordion>
     </TableCell>

--- a/src/components/ReportsPage/HeatmapPage/LevelsInfoCell.tsx
+++ b/src/components/ReportsPage/HeatmapPage/LevelsInfoCell.tsx
@@ -20,6 +20,7 @@ import {
   AccordionDetails,
   TableCell,
   Typography,
+  makeStyles,
 } from '@material-ui/core';
 import { ExpandMore } from '@material-ui/icons';
 import { EntityRefLink } from '@backstage/plugin-catalog-react';
@@ -29,6 +30,13 @@ import { maybePluralize } from '../../../utils/strings';
 import { defaultComponentRefContext } from '../../../utils/ComponentUtils';
 
 import { ScorecardServiceScore } from '../../../api/types';
+import { BackstageTheme } from '@backstage/theme';
+
+const useStyles = makeStyles<BackstageTheme>(_ => ({
+  componentList: {
+    paddingLeft: '16px',
+  },
+}));
 
 interface LevelsInfoCellProps {
   identifier: string;
@@ -36,6 +44,7 @@ interface LevelsInfoCellProps {
 }
 
 export const LevelsInfoCell = ({ identifier, scores }: LevelsInfoCellProps) => {
+  const classes = useStyles();
   return (
     <TableCell>
       <Accordion>
@@ -48,7 +57,7 @@ export const LevelsInfoCell = ({ identifier, scores }: LevelsInfoCellProps) => {
           </Typography>
         </AccordionSummary>
         <AccordionDetails style={{ display: 'flex', flexDirection: 'column' }}>
-          <ul style={{ paddingLeft: 16 }}>
+          <ul className={classes.componentList}>
             {scores?.map(score => (
               <li key={`LevelService-${identifier}-${score.serviceId}`}>
                 <EntityRefLink


### PR DESCRIPTION
## Change description

Fixes the formatting of level-driven service lists for the heatmap report
<img width="722" alt="Screen Shot 2022-05-23 at 2 37 36 PM" src="https://user-images.githubusercontent.com/3069614/169909966-0bc3ea71-d87e-4904-b4fa-152720924747.png">

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## References

[CET-813](https://cortex1.atlassian.net/browse/CET-813)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
