### PR TITLE
fix: add collapse/expand to scorecard description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/Initiatives/InitiativeCard/InitiativeCard.tsx
+++ b/src/components/Initiatives/InitiativeCard/InitiativeCard.tsx
@@ -29,7 +29,6 @@ export const InitiativeCard = ({ initiative }: InitiativeCardProps) => {
   return (
     <ListCard
       name={initiative.name}
-      creatorName={initiative.creator.name}
       description={initiative.description}
       url={initiativeRef({ id: `${initiative.id}` })}
     />

--- a/src/components/ListCard/ListCard.tsx
+++ b/src/components/ListCard/ListCard.tsx
@@ -13,28 +13,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Card, CardActions, CardContent, CardMedia } from '@material-ui/core';
-import React from 'react';
-// import { ItemCardHeader } from '../ItemCardHeader';
+import React, { useMemo } from 'react';
+import { Card, CardActions, CardContent, CardMedia, makeStyles } from '@material-ui/core';
 import {
   Button,
   ItemCardHeader,
   MarkdownContent,
 } from '@backstage/core-components';
+import { BackstageTheme } from '@backstage/theme';
+
+const useStyles = makeStyles<BackstageTheme>(_ => ({
+  linkButton: {
+    backgroundColor: 'transparent',
+    border: 'none',
+    color: '#2E77D0',
+    cursor: 'pointer',
+    fontSize: 14,
+    padding: 0,
+  },
+}));
 
 interface ListCardProps {
-  name: string;
   creatorName: string;
   description?: string;
+  name: string;
+  truncateToCharacters?: number;
   url: string;
 }
 
 export const ListCard = ({
-  name,
   creatorName,
   description,
+  name,
+  truncateToCharacters,
   url,
 }: ListCardProps) => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const classes = useStyles();
+  const descriptionToShow = useMemo(() => {
+    if (!description) {
+      return '';
+    }
+    if (truncateToCharacters && !isExpanded) {
+      return description.substring(0, truncateToCharacters) + '...';
+    }
+
+    return description;
+  }, [description, isExpanded, truncateToCharacters]);
+
   return (
     <Card>
       <CardMedia>
@@ -42,7 +68,12 @@ export const ListCard = ({
       </CardMedia>
       {description && (
         <CardContent>
-          <MarkdownContent content={description} />
+          <MarkdownContent content={descriptionToShow ?? ''} />
+          {
+            truncateToCharacters && description.length > truncateToCharacters && (
+              <button className={classes.linkButton} onClick={() => setIsExpanded(!isExpanded)}>{isExpanded ? 'Less' : 'More'}</button>
+            )
+          }
         </CardContent>
       )}
       <CardActions>

--- a/src/components/ListCard/ListCard.tsx
+++ b/src/components/ListCard/ListCard.tsx
@@ -22,13 +22,13 @@ import {
 } from '@backstage/core-components';
 import { BackstageTheme } from '@backstage/theme';
 
-const useStyles = makeStyles<BackstageTheme>(_ => ({
+const useStyles = makeStyles<BackstageTheme>(styles => ({
   linkButton: {
     backgroundColor: 'transparent',
     border: 'none',
-    color: '#2E77D0',
+    color: styles.palette.primary.main,
     cursor: 'pointer',
-    fontSize: 14,
+    fontSize: styles.typography.body2.fontSize,
     padding: 0,
   },
 }));
@@ -71,6 +71,7 @@ export const ListCard = ({
           <MarkdownContent content={descriptionToShow ?? ''} />
           {
             truncateToCharacters && description.length > truncateToCharacters && (
+              // <Button to={'#'} onClick={() => setIsExpanded(!isExpanded)}>{isExpanded ? 'Less' : 'More'}</Button>
               <button className={classes.linkButton} onClick={() => setIsExpanded(!isExpanded)}>{isExpanded ? 'Less' : 'More'}</button>
             )
           }

--- a/src/components/ListCard/ListCard.tsx
+++ b/src/components/ListCard/ListCard.tsx
@@ -34,7 +34,6 @@ const useStyles = makeStyles<BackstageTheme>(styles => ({
 }));
 
 interface ListCardProps {
-  creatorName: string;
   description?: string;
   name: string;
   truncateToCharacters?: number;
@@ -42,7 +41,6 @@ interface ListCardProps {
 }
 
 export const ListCard = ({
-  creatorName,
   description,
   name,
   truncateToCharacters,
@@ -64,7 +62,7 @@ export const ListCard = ({
   return (
     <Card>
       <CardMedia>
-        <ItemCardHeader title={name} subtitle={`By ${creatorName}`} />
+        <ItemCardHeader title={name} />
       </CardMedia>
       {description && (
         <CardContent>

--- a/src/components/ListCard/ListCard.tsx
+++ b/src/components/ListCard/ListCard.tsx
@@ -71,7 +71,6 @@ export const ListCard = ({
           <MarkdownContent content={descriptionToShow ?? ''} />
           {
             truncateToCharacters && description.length > truncateToCharacters && (
-              // <Button to={'#'} onClick={() => setIsExpanded(!isExpanded)}>{isExpanded ? 'Less' : 'More'}</Button>
               <button className={classes.linkButton} onClick={() => setIsExpanded(!isExpanded)}>{isExpanded ? 'Less' : 'More'}</button>
             )
           }

--- a/src/components/Scorecards/ScorecardCard/ScorecardCard.tsx
+++ b/src/components/Scorecards/ScorecardCard/ScorecardCard.tsx
@@ -28,9 +28,10 @@ export const ScorecardCard = ({ scorecard }: ScorecardCardProps) => {
 
   return (
     <ListCard
-      name={scorecard.name}
       creatorName={scorecard.creator.name}
       description={scorecard.description}
+      name={scorecard.name}
+      truncateToCharacters={200}
       url={scorecardRef({ id: `${scorecard.id}` })}
     />
   );

--- a/src/components/Scorecards/ScorecardCard/ScorecardCard.tsx
+++ b/src/components/Scorecards/ScorecardCard/ScorecardCard.tsx
@@ -28,7 +28,6 @@ export const ScorecardCard = ({ scorecard }: ScorecardCardProps) => {
 
   return (
     <ListCard
-      creatorName={scorecard.creator.name}
       description={scorecard.description}
       name={scorecard.name}
       truncateToCharacters={200}

--- a/src/components/Scorecards/ScorecardsPage/ScorecardsPage.test.tsx
+++ b/src/components/Scorecards/ScorecardsPage/ScorecardsPage.test.tsx
@@ -61,7 +61,6 @@ describe('ScorecardsPage', () => {
     const { findByText } = renderWrapped(<ScorecardsPage />);
     expect(await findByText(/My Scorecard/)).toBeVisible();
     expect(await findByText(/Some description/)).toBeVisible();
-    expect(await findByText(/Billy Bob/)).toBeVisible();
   });
 
   it('should render empty state if no scorecards', async () => {


### PR DESCRIPTION
## Change description

Adds a "Show more" / "Show less" to long scorecard descriptions on the Scorecards page.

### Before
<img width="378" alt="Screen Shot 2022-06-06 at 1 19 32 PM" src="https://user-images.githubusercontent.com/3069614/172244543-f4e461be-6bc2-44c6-b287-37d3ae6ec0a5.png">

### After
<img width="397" alt="Screen Shot 2022-06-06 at 1 18 50 PM" src="https://user-images.githubusercontent.com/3069614/172244498-4462c60b-eed1-4005-845c-847a32d1ae8b.png">

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
