### PR TITLE
[CET-912] Optimize group/system filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardFilterCard/ScorecardFilterCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardFilterCard/ScorecardFilterCard.tsx
@@ -38,6 +38,7 @@ import {
   defaultGroupRefContext,
   defaultSystemRefContext,
 } from '../../../../utils/ComponentUtils';
+import {EntityFilterGroup} from "../../../../filters";
 
 const createRulePredicate = (pass: boolean, ruleExpression: string) => {
   return (score: ScorecardServiceScore) => {
@@ -48,6 +49,37 @@ const createRulePredicate = (pass: boolean, ruleExpression: string) => {
     return rulePassed === pass;
   };
 };
+
+const groupAndSystemFilters: EntityFilterGroup[] = [
+  {
+    name: 'Groups',
+    groupProperty: entity =>
+      getEntityRelations(entity, RELATION_OWNED_BY, {
+        kind: 'group',
+      }).map(entityRef =>
+        stringifyAnyEntityRef(entityRef, { defaultKind: 'group' }),
+      ),
+    formatProperty: (groupRef: string) =>
+      humanizeEntityRef(
+        parseEntityRef(groupRef),
+        defaultGroupRefContext,
+      ),
+  },
+  {
+    name: 'Systems',
+    groupProperty: entity =>
+      getEntityRelations(entity, RELATION_PART_OF, {
+        kind: 'system',
+      }).map(entityRef =>
+        stringifyAnyEntityRef(entityRef, { defaultKind: 'system' }),
+      ),
+    formatProperty: (groupRef: string) =>
+      humanizeEntityRef(
+        parseEntityRef(groupRef),
+        defaultSystemRefContext,
+      ),
+  },
+]
 
 interface ScorecardFilterCardProps {
   scorecard: Scorecard;
@@ -73,36 +105,7 @@ export const ScorecardFilterCard = ({
   const { filterGroups, loading } = useFilters(
     (score: ScorecardServiceScore) => score.componentRef,
     {
-      baseFilters: [
-        {
-          name: 'Groups',
-          groupProperty: entity =>
-            getEntityRelations(entity, RELATION_OWNED_BY, {
-              kind: 'group',
-            }).map(entityRef =>
-              stringifyAnyEntityRef(entityRef, { defaultKind: 'group' }),
-            ),
-          formatProperty: (groupRef: string) =>
-            humanizeEntityRef(
-              parseEntityRef(groupRef),
-              defaultGroupRefContext,
-            ),
-        },
-        {
-          name: 'Systems',
-          groupProperty: entity =>
-            getEntityRelations(entity, RELATION_PART_OF, {
-              kind: 'system',
-            }).map(entityRef =>
-              stringifyAnyEntityRef(entityRef, { defaultKind: 'system' }),
-            ),
-          formatProperty: (groupRef: string) =>
-            humanizeEntityRef(
-              parseEntityRef(groupRef),
-              defaultSystemRefContext,
-            ),
-        },
-      ],
+      baseFilters: groupAndSystemFilters
     },
   );
 


### PR DESCRIPTION
## Change description

Turn group/system/etc filters from `O(#services * #groups)` to `O(#groups)` every time there's an update to one of the filters.


## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
