### PR TITLE
fix: fix error filtering rules by dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/FilterCard/Filters.tsx
+++ b/src/components/FilterCard/Filters.tsx
@@ -162,6 +162,7 @@ export const Filters = <T extends {}>({
       ) : (
         <Grid item sm={12}>
           <Autocomplete
+            aria-label={`Filter ${name.toLowerCase()}`}
             options={Object.values(filters)}
             getOptionLabel={filter => filter.display}
             multiple

--- a/src/components/FilterCard/Filters.tsx
+++ b/src/components/FilterCard/Filters.tsx
@@ -43,9 +43,15 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+export interface FilterValue {
+  display: string,
+  value: string,
+  id: string,
+}
+
 export interface FilterDefinition<T> {
   name: string;
-  filters: { [id: string]: { display: string; value: string } };
+  filters: { [id: string]: FilterValue };
   generatePredicate: (value: string) => Predicate<T>;
 }
 
@@ -83,10 +89,10 @@ export const Filters = <T extends {}>({
     });
   };
 
-  const toggleAllFilters = (allCheckedFilters: string[]) => {
+  const toggleAllFilters = (allCheckedFilters: FilterValue[]) => {
     setCheckedFilters(() => {
       const newFilters = mapValues(
-        mapByString(allCheckedFilters, filter => filter),
+        mapByString(allCheckedFilters, filter => filter.id),
         () => true,
       );
       updatePredicate(newFilters, oneOf);
@@ -160,11 +166,7 @@ export const Filters = <T extends {}>({
             getOptionLabel={filter => filter.display}
             multiple
             onChange={(_event, values) => {
-              toggleAllFilters(
-                (values as { display: string; value: string }[]).map(
-                  filter => filter.value,
-                ),
-              );
+              toggleAllFilters(values);
             }}
             renderInput={params => <TextField {...params} variant="standard" />}
           />

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeFilterCard/InitiativeFilterCard.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeFilterCard/InitiativeFilterCard.tsx
@@ -76,6 +76,7 @@ export const InitiativeFilterCard = ({
         return {
           display: ruleName(rule),
           value: rule.expression,
+          id: rule.ruleId.toString(),
         };
       },
     );

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetailsPage.test.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetailsPage.test.tsx
@@ -143,6 +143,8 @@ describe('ScorecardDetailsPage', () => {
         ],
       });
     };
+    // For some reason, checks would never fail if I used the methods returned
+    // by `render()` so I had to use `screen.*` methods directly here
     render(mockCortexApi);
 
     expect(await screen.findByText(/Failing Rule/)).toBeVisible();

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetailsPage.test.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetailsPage.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
 import { ScorecardDetailsPage } from "./ScorecardDetailsPage";
 import { Fixtures, renderWrapped } from "../../../utils/TestUtils";
 import { CortexApi } from "../../../api/CortexApi";
@@ -23,6 +24,7 @@ import { CatalogApi, catalogApiRef } from "@backstage/plugin-catalog-react";
 import { CustomMapping, ExtensionApi } from "@cortexapps/backstage-plugin-extensions";
 import { EntityFilterGroup } from "../../../filters";
 import { extensionApiRef } from "../../../api/ExtensionApi";
+import { act } from 'react-dom/test-utils';
 
 describe('ScorecardDetailsPage', () => {
 
@@ -84,11 +86,11 @@ describe('ScorecardDetailsPage', () => {
     }
   }
 
-  function render() {
+  function render(cortexApiOverride: Partial<CortexApi> = cortexApi) {
     return renderWrapped(<ScorecardDetailsPage />, {
       '/': rootRouteRef,
       '/scorecards/:id': scorecardRouteRef as any,
-    }, cortexApi,[catalogApiRef, catalogApi], [extensionApiRef, emptyExtensionApi]);
+    }, cortexApiOverride,[catalogApiRef, catalogApi], [extensionApiRef, emptyExtensionApi]);
   }
 
 
@@ -111,20 +113,54 @@ describe('ScorecardDetailsPage', () => {
     await checkNotText('bar');
     await clickButton('Filter groups by mine');
 
-    await clickButton('Filter groups by shared')
+    await clickButton('Filter groups by shared');
     await checkForText('foo');
     await checkForText('bar');
-    await clickButton('Filter groups by shared')
+    await clickButton('Filter groups by shared');
 
-    await clickButton('Filter groups by alsomine')
+    await clickButton('Filter groups by alsomine');
     await checkNotText('foo');
     await checkForText('bar');
-    await clickButton('Filter groups by alsomine')
+    await clickButton('Filter groups by alsomine');
+  });
+
+  it('can filter when there are a large number of rules', async () => {
+    const mockCortexApi: Partial<CortexApi> = { ...cortexApi };
+    mockCortexApi.getScorecard = async (_: number): Promise<Scorecard | undefined> => {
+      return Fixtures.scorecard({
+        rules: [
+          { id: 1, expression: 'git.enabled', description: 'Has Git', weight: 10 },
+          { id: 2, expression: 'runbooks.count > 0', description: 'My Rule', weight: 10 },
+          { id: 3, expression: 'documentation.count > 0', weight: 20 },
+          { id: 4, expression: 'custom("foo").length > 1', weight: 20 },
+          { id: 5, expression: 'custom("bar").length > 6', weight: 5 },
+          { id: 6, expression: 'custom("baz").length > 3', weight: 5 },
+          { id: 7, expression: 'custom("custom").length > 4', weight: 5 },
+          { id: 8, expression: 'custom("cow").length > 8', weight: 5 },
+          { id: 9, expression: 'custom("length").length > 9', weight: 5 },
+          { id: 10, expression: 'custom("cortex").length > 10', weight: 5 },
+          { id: 11, expression: 'custom("xyz").length > 2', weight: 1 },
+        ],
+      });
+    };
+    render(mockCortexApi);
+
+    expect(await screen.findByText(/Failing Rule/)).toBeVisible();
+    fireEvent.click(await screen.findByLabelText(/Filter failing rule/));
+
+    const dropdownOption = await screen.findByText(/documentation.count/, { selector: 'li' });
+    await screen.findByText(/custom\("cow"\).length/, { selector: 'li' });
+    act(async () => {
+      fireEvent.click(dropdownOption);
+    });
+
+    expect(await screen.findByText(/Failing Rule/)).toBeVisible();
+    expect(await screen.queryByText(/custom\("cow"\).length/, { selector: 'li' })).not.toBeInTheDocument();
   });
 
   // MUI select is broken in a weird way, can't test
   it.skip('should filter with any of / all of working correctly', async () => {
-    const { mouseClick, clickButton, clickButtonByText, checkForText, checkNotText, logScreen } = render()
+    const { mouseClick, clickButton, clickButtonByText, checkForText, checkNotText, logScreen } = render();
 
     await clickButton('Filter groups by mine');
     await clickButton('Filter groups by alsomine');
@@ -132,7 +168,7 @@ describe('ScorecardDetailsPage', () => {
     await checkForText('bar');
 
     await mouseClick('Select and/or for groups');
-    logScreen()
+    logScreen();
     await clickButtonByText('All Of');
     await checkNotText('foo');
     await checkNotText('bar');

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardFilterCard/ScorecardFilterCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardFilterCard/ScorecardFilterCard.tsx
@@ -97,6 +97,7 @@ export const ScorecardFilterCard = ({
         return {
           display: ruleName(rule),
           value: rule.expression,
+          id: rule.id.toString(),
         };
       },
     );

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -295,6 +295,7 @@ export function useFilters<T>(
                 ? filterGroup.formatProperty(groupProperty)
                 : groupProperty,
               value: groupProperty,
+              id: groupProperty,
             };
           },
         ),


### PR DESCRIPTION
## Change description

Scorecards and initiatives that have >10 rules see a dropdown for filtering by rule. Currently, selecting an option causes a JavaScript error to be thrown. This PR fixes the underlying issue, allowing the filter to be properly applied.

**Before**

https://user-images.githubusercontent.com/3069614/173956699-9c4f999a-97fe-40c6-ab77-cf03dfd6d4b1.mov

**After**

https://user-images.githubusercontent.com/3069614/173956833-2777b722-e04e-4969-b193-865ddc9d8250.mov


## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
