### PR TITLE
fix: point 'main' and 'types' to dist folder to fix import targets for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
   "name": "@cortexapps/backstage-plugin",
   "version": "1.2.9",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "repository": "github:cortexapps/backstage-plugin",
   "publishConfig": {
-    "access": "public",
-    "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "access": "public"
   },
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
patches the definition of main and types in package.json to be consistent for local development and what is published.

## Change description

Why am I making this change?

I've been following the guide for getting our backstage dev environment set up.  I kept running into some weird behavior where the first time i `yalc add ....` the backstage-plugin dep into the backstage repo, it worked, but would fail everytime after i did a `yalc push` in the backstage plugin to update the code.

on further inspection I could see that yalc was dragging over `src/index.ts` even if `src/` was added to `.npmignore`.  `npm pack` was not dragging the file into the `gz` archive of the package.  I was getting confused.

Eventually I noticed these fields in package.json pointing towards `src/index.ts`.  Those should always point to the transpiled files in `dist`, and making that change fixed the weird error where yalc was dragging in the src file and only that src file.  it would barf trying to pull in all the other files in src directory that `src/index` referenced.  (maybe yalc ignored the `publishConfig` field entirely... seems like a likely bug)

A side effect of this change for the local workflow with this plugin is that we will need to be constantly building to `dist` with a watcher while we work.  instead of relying on hot-reloading directly from changes in src file while working in the `backstage` repo.

TL;DR;  `@cortexapps/backstage-plugin` is meant to be installed as a dependency, so keep that consistent between local development vs using the public package.


## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
