### PR TITLE
feat: add support for self-hosted cortex links

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ import { CortexGroupActionItemsWidget } from '@cortexapps/backstage-plugin';
 </EntityLayout.Route>
 ```
 
+10. (Optional) Update `app-config.yaml` to point to a self-hosted instance.
+
+```yaml
+cortex:
+  frontendBaseUrl: ${CORTEX_FRONTEND_HOST_URL}
+```
+
 
 ## Advanced
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "1.2.14",
+  "version": "1.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -118,7 +118,9 @@
     ]
   },
   "files": [
+    "config.d.ts",
     "dist",
     "src"
-  ]
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/src/components/Scorecards/ScorecardsPage/ScorecardsPage.tsx
+++ b/src/components/Scorecards/ScorecardsPage/ScorecardsPage.tsx
@@ -60,6 +60,7 @@ const ScorecardsPageBody = () => {
   }
 
   if (error) {
+    console.log({ error });
     return (
       <WarningPanel severity="error" title="Could not load scorecards.">
         {error.message}
@@ -111,6 +112,7 @@ export const ScorecardsPage = () => {
   }
 
   if (error) {
+    console.log({ error });
     return (
       <WarningPanel severity="error" title="Could not load scorecards.">
         {error.message}

--- a/src/components/Scorecards/ScorecardsPage/ScorecardsPage.tsx
+++ b/src/components/Scorecards/ScorecardsPage/ScorecardsPage.tsx
@@ -60,7 +60,6 @@ const ScorecardsPageBody = () => {
   }
 
   if (error) {
-    console.log({ error });
     return (
       <WarningPanel severity="error" title="Could not load scorecards.">
         {error.message}
@@ -112,7 +111,6 @@ export const ScorecardsPage = () => {
   }
 
   if (error) {
-    console.log({ error });
     return (
       <WarningPanel severity="error" title="Could not load scorecards.">
         {error.message}

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 import React, { useEffect, useState } from 'react';
-import { configApiRef, useApi, useRouteRefParams } from '@backstage/core-plugin-api';
+import {
+  configApiRef,
+  useApi,
+  useRouteRefParams,
+} from '@backstage/core-plugin-api';
 import {
   Content,
   InfoCard,
@@ -115,7 +119,11 @@ export const ScorecardsServicePage = () => {
         </Box>
         <Box alignSelf="center">
           <Link
-            to={cortexScorecardServicePageURL({scorecardId, serviceId: score.serviceId, cortexURL: cortexBaseUrl})}
+            to={cortexScorecardServicePageURL({
+              scorecardId,
+              serviceId: score.serviceId,
+              cortexURL: cortexBaseUrl,
+            })}
             target="_blank"
           >
             <b>View in Cortex</b>

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React, { useEffect, useState } from 'react';
-import { useApi, useRouteRefParams } from '@backstage/core-plugin-api';
+import { configApiRef, useApi, useRouteRefParams } from '@backstage/core-plugin-api';
 import {
   Content,
   InfoCard,
@@ -44,6 +44,9 @@ const useStyles = makeStyles({
 
 export const ScorecardsServicePage = () => {
   const cortexApi = useApi(cortexApiRef);
+  const config = useApi(configApiRef);
+
+  console.log({ configKeys: config.keys() });
 
   const { scorecardId, kind, namespace, name } = useRouteRefParams(
     scorecardServiceDetailsRouteRef,
@@ -56,6 +59,9 @@ export const ScorecardsServicePage = () => {
   const [selectedRules, setSelectedRules] = useState<
     ScorecardServiceScoresRule[]
   >([]);
+
+  const cortexBaseUrl = config.getOptionalString('cortex.frontendBaseUrl');
+  console.log({ cortexBaseUrl });
 
   const { value, loading, error } = useAsync(async () => {
     const allScores = await cortexApi.getScorecardScores(+scorecardId);
@@ -112,7 +118,7 @@ export const ScorecardsServicePage = () => {
         </Box>
         <Box alignSelf="center">
           <Link
-            to={cortexScorecardServicePageURL(scorecardId, score.serviceId)}
+            to={cortexScorecardServicePageURL({scorecardId, serviceId: score.serviceId, cortexURL: cortexBaseUrl})}
             target="_blank"
           >
             <b>View in Cortex</b>

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
@@ -46,8 +46,6 @@ export const ScorecardsServicePage = () => {
   const cortexApi = useApi(cortexApiRef);
   const config = useApi(configApiRef);
 
-  console.log({ configKeys: config.keys() });
-
   const { scorecardId, kind, namespace, name } = useRouteRefParams(
     scorecardServiceDetailsRouteRef,
   );
@@ -61,7 +59,6 @@ export const ScorecardsServicePage = () => {
   >([]);
 
   const cortexBaseUrl = config.getOptionalString('cortex.frontendBaseUrl');
-  console.log({ cortexBaseUrl });
 
   const { value, loading, error } = useAsync(async () => {
     const allScores = await cortexApi.getScorecardScores(+scorecardId);

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceProgress.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceProgress.tsx
@@ -113,7 +113,7 @@ export const ScorecardsServiceProgress = ({
           <Button
             variant="contained"
             color="primary"
-            href={cortexScorecardPageURL(scorecardId)}
+            href={cortexScorecardPageURL({scorecardId})}
           >
             Go to Cortex
           </Button>

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceProgress.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceProgress.tsx
@@ -113,7 +113,7 @@ export const ScorecardsServiceProgress = ({
           <Button
             variant="contained"
             color="primary"
-            href={cortexScorecardPageURL({scorecardId})}
+            href={cortexScorecardPageURL({ scorecardId })}
           >
             Go to Cortex
           </Button>

--- a/src/utils/URLUtils.test.ts
+++ b/src/utils/URLUtils.test.ts
@@ -13,26 +13,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { cortexScorecardPageURL, cortexScorecardServicePageURL } from "./URLUtils";
+import {
+  cortexScorecardPageURL,
+  cortexScorecardServicePageURL,
+} from './URLUtils';
 
 describe('URLUtils', () => {
   describe('cortexScorecardPageURL', () => {
     it('should use default cortex url', () => {
-      expect(cortexScorecardPageURL({scorecardId: '1'})).toEqual('https://app.getcortexapp.com/admin/scorecards/1');
+      expect(cortexScorecardPageURL({ scorecardId: '1' })).toEqual(
+        'https://app.getcortexapp.com/admin/scorecards/1',
+      );
     });
 
     it('should use the provided url', () => {
-      expect(cortexScorecardPageURL({scorecardId: '1', cortexURL: 'https://test.domain'})).toEqual('https://test.domain/admin/scorecards/1');
+      expect(
+        cortexScorecardPageURL({
+          scorecardId: '1',
+          cortexURL: 'https://test.domain',
+        }),
+      ).toEqual('https://test.domain/admin/scorecards/1');
     });
   });
 
   describe('cortexScorecardServicePageURL', () => {
     it('should use default url', () => {
-      expect(cortexScorecardServicePageURL({scorecardId: '1', serviceId: '1'})).toEqual('https://app.getcortexapp.com/admin/scorecards/1?service=1');
+      expect(
+        cortexScorecardServicePageURL({ scorecardId: '1', serviceId: '1' }),
+      ).toEqual('https://app.getcortexapp.com/admin/scorecards/1?service=1');
     });
 
     it('should use custom domain url', () => {
-      expect(cortexScorecardServicePageURL({scorecardId: '1', serviceId: '1', cortexURL: 'https://test.domain'})).toEqual('https://test.domain/admin/scorecards/1?service=1');
+      expect(
+        cortexScorecardServicePageURL({
+          scorecardId: '1',
+          serviceId: '1',
+          cortexURL: 'https://test.domain',
+        }),
+      ).toEqual('https://test.domain/admin/scorecards/1?service=1');
     });
   });
 });

--- a/src/utils/URLUtils.test.ts
+++ b/src/utils/URLUtils.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cortexScorecardPageURL, cortexScorecardServicePageURL } from "./URLUtils";
+
+describe('URLUtils', () => {
+  describe('cortexScorecardPageURL', () => {
+    it('should use default cortex url', () => {
+      expect(cortexScorecardPageURL({scorecardId: '1'})).toEqual('https://app.getcortexapp.com/admin/scorecards/1');
+    });
+
+    it('should use the provided url', () => {
+      expect(cortexScorecardPageURL({scorecardId: '1', cortexURL: 'https://test.domain'})).toEqual('https://test.domain/admin/scorecards/1');
+    });
+  });
+
+  describe('cortexScorecardServicePageURL', () => {
+    it('should use default url', () => {
+      expect(cortexScorecardServicePageURL({scorecardId: '1', serviceId: '1'})).toEqual('https://app.getcortexapp.com/admin/scorecards/1?service=1');
+    });
+
+    it('should use custom domain url', () => {
+      expect(cortexScorecardServicePageURL({scorecardId: '1', serviceId: '1', cortexURL: 'https://test.domain'})).toEqual('https://test.domain/admin/scorecards/1?service=1');
+    });
+  });
+});

--- a/src/utils/URLUtils.ts
+++ b/src/utils/URLUtils.ts
@@ -23,7 +23,7 @@ interface CortexScorecardServicePageURLProperties {
 
 interface CortexScorecardPageURLProperties {
   scorecardId: string | number;
-  cortexURL?: string
+  cortexURL?: string;
 }
 
 export const buildUrl = (
@@ -35,13 +35,17 @@ export const buildUrl = (
     query: queryParamsObj,
   })}`;
 
-  const defaultCortexURL = 'https://app.getcortexapp.com';
+const defaultCortexURL = 'https://app.getcortexapp.com';
 
-  export const cortexScorecardPageURL = ({scorecardId, cortexURL = defaultCortexURL}: CortexScorecardPageURLProperties) => `${cortexURL}/admin/scorecards/${scorecardId}`;
-  
-  export const cortexScorecardServicePageURL = ({
-    scorecardId,
-    serviceId,
-    cortexURL
-  }: CortexScorecardServicePageURLProperties
-  ) => `${cortexScorecardPageURL({scorecardId, cortexURL})}?service=${serviceId}`;
+export const cortexScorecardPageURL = ({
+  scorecardId,
+  cortexURL = defaultCortexURL,
+}: CortexScorecardPageURLProperties) =>
+  `${cortexURL}/admin/scorecards/${scorecardId}`;
+
+export const cortexScorecardServicePageURL = ({
+  scorecardId,
+  serviceId,
+  cortexURL,
+}: CortexScorecardServicePageURLProperties) =>
+  `${cortexScorecardPageURL({ scorecardId, cortexURL })}?service=${serviceId}`;

--- a/src/utils/URLUtils.ts
+++ b/src/utils/URLUtils.ts
@@ -15,6 +15,17 @@
  */
 import { StringifiableRecord, stringifyUrl } from 'query-string';
 
+interface CortexScorecardServicePageURLProperties {
+  scorecardId: string | number;
+  serviceId: string | number;
+  cortexURL?: string;
+}
+
+interface CortexScorecardPageURLProperties {
+  scorecardId: string | number;
+  cortexURL?: string
+}
+
 export const buildUrl = (
   queryParamsObj: StringifiableRecord,
   pathname: string,
@@ -24,12 +35,13 @@ export const buildUrl = (
     query: queryParamsObj,
   })}`;
 
-const cortexURL = 'https://app.getcortexapp.com/admin/';
+  const defaultCortexURL = 'https://app.getcortexapp.com';
 
-export const cortexScorecardPageURL = (scorecardId: string | number) =>
-  `${cortexURL}scorecards/${scorecardId}`;
-
-export const cortexScorecardServicePageURL = (
-  scorecardId: string | number,
-  serviceId: string | number,
-) => `${cortexScorecardPageURL(scorecardId)}?service=${serviceId}`;
+  export const cortexScorecardPageURL = ({scorecardId, cortexURL = defaultCortexURL}: CortexScorecardPageURLProperties) => `${cortexURL}/admin/scorecards/${scorecardId}`;
+  
+  export const cortexScorecardServicePageURL = ({
+    scorecardId,
+    serviceId,
+    cortexURL
+  }: CortexScorecardServicePageURLProperties
+  ) => `${cortexScorecardPageURL({scorecardId, cortexURL})}?service=${serviceId}`;


### PR DESCRIPTION
## Change description

On Service Scorecards page, we expose a "View in Cortex" link to send users from backstage to the Cortex app. However, we currently only link to the cloud URL so self-hosted users are sent to a 404.

This PR allows users to optionally configure the frontend URL for the Cortex app so they can easily point the link to their own deployment.

Most of the credit for this PR goes to @jsundquist for opening the initial version of this in https://github.com/cortexapps/backstage-plugin/pull/84 -- I merely did some connecting of dots to ensure everything propagated through as expected.

## Type of change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

https://github.com/cortexapps/backstage-plugin/pull/84

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
