### PR TITLE
CET-1147 move backstage sync job to background task

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/api/CortexApi.ts
+++ b/src/api/CortexApi.ts
@@ -81,15 +81,15 @@ export interface CortexApi {
     entityRefs: AnyEntityRef[],
   ): Promise<InitiativeActionItem[]>;
 
-  submitSyncTask(
+  submitEntitySync(
     entities: Entity[],
     customMappings?: CustomMapping[],
     teamOverrides?: TeamOverrides,
   ): Promise<EntitySyncProgress>;
 
-  getSyncTaskProgress(): Promise<EntitySyncProgress>;
+  getEntitySyncProgress(): Promise<EntitySyncProgress>;
 
-  getLastSyncTime(): Promise<LastEntitySyncTime>;
+  getLastEntitySyncTime(): Promise<LastEntitySyncTime>;
 
-  cancelSync(): Promise<void>;
+  cancelEntitySync(): Promise<void>;
 }

--- a/src/api/CortexApi.ts
+++ b/src/api/CortexApi.ts
@@ -19,6 +19,7 @@ import {
   Initiative,
   InitiativeActionItem,
   InitiativeWithScores,
+  LastEntitySyncTime,
   Scorecard,
   ScorecardLadder,
   ScorecardResult,
@@ -86,7 +87,7 @@ export interface CortexApi {
     teamOverrides?: TeamOverrides,
   ): Promise<EntitySyncProgress>;
 
-  getSyncTaskProgress(): Promise<EntitySyncProgress | undefined>;
+  getSyncTaskProgress(): Promise<EntitySyncProgress>;
 
-  getLastSyncTime(): Promise<EntitySyncProgress | undefined>;
+  getLastSyncTime(): Promise<LastEntitySyncTime>;
 }

--- a/src/api/CortexApi.ts
+++ b/src/api/CortexApi.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {
+  EntitySyncProgress,
   GroupByOption,
   Initiative,
   InitiativeActionItem,
@@ -29,7 +30,10 @@ import {
 import { Entity } from '@backstage/catalog-model';
 import { Moment } from 'moment/moment';
 import { AnyEntityRef } from '../utils/types';
-import { CustomMapping, TeamOverrides } from '@cortexapps/backstage-plugin-extensions';
+import {
+  CustomMapping,
+  TeamOverrides,
+} from '@cortexapps/backstage-plugin-extensions';
 
 export interface CortexApi {
   getScorecards(): Promise<Scorecard[]>;
@@ -76,9 +80,13 @@ export interface CortexApi {
     entityRefs: AnyEntityRef[],
   ): Promise<InitiativeActionItem[]>;
 
-  syncEntities(
+  submitSyncTask(
     entities: Entity[],
     customMappings?: CustomMapping[],
-    teamOverrides?: TeamOverrides
-  ): Promise<void>;
+    teamOverrides?: TeamOverrides,
+  ): Promise<EntitySyncProgress>;
+
+  getSyncTaskProgress(): Promise<EntitySyncProgress | undefined>;
+
+  getLastSyncTime(): Promise<EntitySyncProgress | undefined>;
 }

--- a/src/api/CortexApi.ts
+++ b/src/api/CortexApi.ts
@@ -90,4 +90,6 @@ export interface CortexApi {
   getSyncTaskProgress(): Promise<EntitySyncProgress>;
 
   getLastSyncTime(): Promise<LastEntitySyncTime>;
+
+  cancelSync(): Promise<void>;
 }

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -239,7 +239,6 @@ export class CortexClient implements CortexApi {
   }
 
   async getSyncTaskProgress(): Promise<EntitySyncProgress> {
-    // return { percentage: 0.22 };
     return await this.get(`/api/backstage/v1/entities/progress`);
   }
 
@@ -249,7 +248,6 @@ export class CortexClient implements CortexApi {
 
   async cancelSync(): Promise<void> {
     await this.delete(`/api/backstage/v1/entities/sync`);
-    return;
   }
 
   private async getBasePath(): Promise<string> {
@@ -314,7 +312,7 @@ export class CortexClient implements CortexApi {
     return response.json();
   }
 
-  private async delete(path: string, body?: any): Promise<Response> {
+  private async delete(path: string, body?: any): Promise<void> {
     const basePath = await this.getBasePath();
     const url = `${basePath}${path}`;
 
@@ -327,8 +325,6 @@ export class CortexClient implements CortexApi {
     if (response.status !== 200) {
       throw new Error(`Error communicating with Cortex`);
     }
-
-    return response;
   }
 
   private async fetchAuthenticated(

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -247,6 +247,11 @@ export class CortexClient implements CortexApi {
     return await this.get(`/api/backstage/v1/entities/last-sync`);
   }
 
+  async cancelSync(): Promise<void> {
+    await this.delete(`/api/backstage/v1/entities/sync`);
+    return;
+  }
+
   private async getBasePath(): Promise<string> {
     const proxyBasePath = await this.discoveryApi.getBaseUrl('proxy');
     return `${proxyBasePath}/cortex`;
@@ -307,6 +312,23 @@ export class CortexClient implements CortexApi {
     }
 
     return response.json();
+  }
+
+  private async delete(path: string, body?: any): Promise<Response> {
+    const basePath = await this.getBasePath();
+    const url = `${basePath}${path}`;
+
+    const response = await this.fetchAuthenticated(url, {
+      method: 'DELETE',
+      body: body && JSON.stringify(body),
+      headers: body && { 'Content-Type': 'application/json' },
+    });
+
+    if (response.status !== 200) {
+      throw new Error(`Error communicating with Cortex`);
+    }
+
+    return response;
   }
 
   private async fetchAuthenticated(

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -20,6 +20,7 @@ import {
   Initiative,
   InitiativeActionItem,
   InitiativeWithScores,
+  LastEntitySyncTime,
   Scorecard,
   ScorecardLadder,
   ScorecardResult,
@@ -237,12 +238,12 @@ export class CortexClient implements CortexApi {
     );
   }
 
-  async getSyncTaskProgress(): Promise<EntitySyncProgress | undefined> {
+  async getSyncTaskProgress(): Promise<EntitySyncProgress> {
     // return { percentage: 0.22 };
     return await this.get(`/api/backstage/v1/entities/progress`);
   }
 
-  async getLastSyncTime(): Promise<EntitySyncProgress | undefined> {
+  async getLastSyncTime(): Promise<LastEntitySyncTime> {
     return await this.get(`/api/backstage/v1/entities/last-sync`);
   }
 

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -72,7 +72,7 @@ export class CortexClient implements CortexApi {
     return await this.get(`/api/backstage/v1/scorecards`);
   }
 
-  async submitSyncTask(
+  async submitEntitySync(
     entities: Entity[],
     customMappings?: CustomMapping[],
     teamOverrides?: TeamOverrides,
@@ -238,15 +238,15 @@ export class CortexClient implements CortexApi {
     );
   }
 
-  async getSyncTaskProgress(): Promise<EntitySyncProgress> {
+  async getEntitySyncProgress(): Promise<EntitySyncProgress> {
     return await this.get(`/api/backstage/v1/entities/progress`);
   }
 
-  async getLastSyncTime(): Promise<LastEntitySyncTime> {
+  async getLastEntitySyncTime(): Promise<LastEntitySyncTime> {
     return await this.get(`/api/backstage/v1/entities/last-sync`);
   }
 
-  async cancelSync(): Promise<void> {
+  async cancelEntitySync(): Promise<void> {
     await this.delete(`/api/backstage/v1/entities/sync`);
   }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -277,9 +277,9 @@ export interface InitiativeActionItem {
 }
 
 export interface EntitySyncProgress {
-  percentage: number;
+  percentage: number | null;
 }
 
 export interface LastEntitySyncTime {
-  lastSynced: string;
+  lastSynced: string | null;
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -275,3 +275,11 @@ export interface InitiativeActionItem {
     description?: string;
   };
 }
+
+export interface EntitySyncProgress {
+  percentage: number;
+}
+
+export interface LastEntitySyncTime {
+  lastSynced: string;
+}

--- a/src/components/Common/PollingLinearGauge.tsx
+++ b/src/components/Common/PollingLinearGauge.tsx
@@ -19,7 +19,7 @@ import React, { useState } from 'react';
 import { ExponentialBackoff } from '../../utils/MathUtils';
 import { useInterval } from '../../utils/HookUtils';
 
-interface PollingProgressBarProps {
+interface PollingLinearGaugeProps {
   backoffMultiplier?: number;
   done?: boolean;
   initialDelay?: number;
@@ -28,7 +28,7 @@ interface PollingProgressBarProps {
   value: number;
 }
 
-export const PollingProgressBar: React.FC<PollingProgressBarProps> = ({
+const PollingLinearGauge: React.FC<PollingLinearGaugeProps> = ({
   backoffMultiplier = 1.2,
   done = false,
   initialDelay = 1000,
@@ -58,4 +58,4 @@ export const PollingProgressBar: React.FC<PollingProgressBarProps> = ({
   return <LinearGauge value={value} />;
 };
 
-export default PollingProgressBar;
+export default PollingLinearGauge;

--- a/src/components/Common/PollingProgressBar.tsx
+++ b/src/components/Common/PollingProgressBar.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LinearGauge } from '@backstage/core-components';
+import React, { useState } from 'react';
+import { ExponentialBackoff } from '../../utils/MathUtils';
+import { useInterval } from '../../utils/HookUtils';
+
+interface PollingProgressBarProps {
+  backoffMultiplier?: number;
+  done?: boolean;
+  initialDelay?: number;
+  maxDelay?: number;
+  poll: () => Promise<void>;
+  value: number;
+}
+
+export const PollingProgressBar: React.FC<PollingProgressBarProps> = ({
+  backoffMultiplier = 1.2,
+  done = false,
+  initialDelay = 1000,
+  maxDelay = 1000,
+  poll,
+  value,
+}) => {
+  const isDone = value === 1 || done;
+
+  const [exponentialBackoff, setExponentialBackoff] = useState(
+    () =>
+      new ExponentialBackoff({
+        initialDelay: initialDelay,
+        multiplier: backoffMultiplier,
+        maxDelay: maxDelay,
+      }),
+  );
+
+  useInterval(
+    async () => {
+      await poll();
+      setExponentialBackoff(backoff => backoff.advance());
+    },
+    isDone ? null : exponentialBackoff.delay(),
+  );
+
+  return <LinearGauge value={value} />;
+};
+
+export default PollingProgressBar;

--- a/src/components/SettingsPage/SettingsPage.test.tsx
+++ b/src/components/SettingsPage/SettingsPage.test.tsx
@@ -105,8 +105,11 @@ describe('<SettingsPage/>', () => {
   const cortexApi = mock<CortexApi>();
 
   it('should submit entity sync with custom mappings and group overrides', async () => {
-    cortexApi.submitSyncTask.mockResolvedValue({ percentage: null });
-    cortexApi.getSyncTaskProgress.mockResolvedValue({ percentage: null });
+    cortexApi.submitEntitySync.mockResolvedValue({ percentage: null });
+    cortexApi.getEntitySyncProgress.mockResolvedValue({ percentage: null });
+    cortexApi.getLastEntitySyncTime.mockResolvedValue({
+      lastSynced: null,
+    });
     const { clickButton, checkForText, queryByLabelText } = renderWrapped(
       <SettingsPage />,
       cortexApi,
@@ -128,7 +131,7 @@ describe('<SettingsPage/>', () => {
     );
     await checkForText(/Entities have never been synced before/);
     const customMappingsCaptor = captor();
-    expect(cortexApi.submitSyncTask).toHaveBeenLastCalledWith(
+    expect(cortexApi.submitEntitySync).toHaveBeenLastCalledWith(
       [component1, component2],
       customMappingsCaptor,
       { teams, relationships },
@@ -139,7 +142,10 @@ describe('<SettingsPage/>', () => {
   });
 
   it('shows in progress entity sync', async () => {
-    cortexApi.getSyncTaskProgress.mockResolvedValue({ percentage: 0.7 });
+    cortexApi.getEntitySyncProgress.mockResolvedValue({ percentage: 0.7 });
+    cortexApi.getLastEntitySyncTime.mockResolvedValue({
+      lastSynced: null,
+    });
     const { checkForText, getByTestId, queryByLabelText } = renderWrapped(
       <SettingsPage />,
       cortexApi,
@@ -154,8 +160,8 @@ describe('<SettingsPage/>', () => {
   });
 
   it('shows the last sync time', async () => {
-    cortexApi.getSyncTaskProgress.mockResolvedValue({ percentage: null });
-    cortexApi.getLastSyncTime.mockResolvedValue({
+    cortexApi.getEntitySyncProgress.mockResolvedValue({ percentage: null });
+    cortexApi.getLastEntitySyncTime.mockResolvedValue({
       lastSynced: '2000-01-01T00:00:00',
     });
     const { checkForText, queryByLabelText } = renderWrapped(

--- a/src/components/SettingsPage/SettingsPage.test.tsx
+++ b/src/components/SettingsPage/SettingsPage.test.tsx
@@ -106,6 +106,7 @@ describe('<SettingsPage/>', () => {
 
   it('should submit entity sync with custom mappings and group overrides', async () => {
     cortexApi.submitSyncTask.mockResolvedValue({ percentage: null });
+    cortexApi.getSyncTaskProgress.mockResolvedValue({ percentage: null });
     const { clickButton, checkForText, queryByLabelText } = renderWrapped(
       <SettingsPage />,
       cortexApi,
@@ -139,7 +140,7 @@ describe('<SettingsPage/>', () => {
 
   it('shows in progress entity sync', async () => {
     cortexApi.getSyncTaskProgress.mockResolvedValue({ percentage: 0.7 });
-    const { checkForText, queryByLabelText } = renderWrapped(
+    const { checkForText, getByTestId, queryByLabelText } = renderWrapped(
       <SettingsPage />,
       cortexApi,
       {},
@@ -149,6 +150,7 @@ describe('<SettingsPage/>', () => {
 
     await checkForText(/Entities have never been synced before/);
     expect(await queryByLabelText(/Cancel entity sync/)).toBeVisible();
+    expect(getByTestId('PollingLinearGauge-entity-sync')).toBeVisible();
   });
 
   it('shows the last sync time', async () => {

--- a/src/components/SettingsPage/SettingsPage.test.tsx
+++ b/src/components/SettingsPage/SettingsPage.test.tsx
@@ -13,27 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CortexApi } from "../../api/CortexApi";
-import React from "react";
-import { CatalogApi, catalogApiRef } from "@backstage/plugin-catalog-react";
-import { Fixtures } from "../../utils/TestUtils";
-import { renderWrapped } from "../../utils/TestUtils";
-import { SettingsPage } from "./SettingsPage";
+import { CortexApi } from '../../api/CortexApi';
+import React from 'react';
+import { CatalogApi, catalogApiRef } from '@backstage/plugin-catalog-react';
+import { Fixtures } from '../../utils/TestUtils';
+import { renderWrapped } from '../../utils/TestUtils';
+import { SettingsPage } from './SettingsPage';
 import { captor, mock } from 'jest-mock-extended';
-import { ExtensionApi } from "@cortexapps/backstage-plugin-extensions";
-import { extensionApiRef } from "../../api/ExtensionApi";
-import { waitFor } from "@testing-library/react";
+import { ExtensionApi } from '@cortexapps/backstage-plugin-extensions';
+import { extensionApiRef } from '../../api/ExtensionApi';
+import { waitFor } from '@testing-library/react';
 
 describe('<SettingsPage/>', () => {
-
   const component1 = Fixtures.entity({
     kind: 'Component',
     metadata: Fixtures.entityMeta({ name: 'foo' }),
     relations: [
       { type: 'ownedBy', targetRef: 'Group:shared' },
       { type: 'ownedBy', targetRef: 'Group:mine' },
-    ]
-  })
+    ],
+  });
 
   const component2 = Fixtures.entity({
     kind: 'Component',
@@ -41,92 +40,133 @@ describe('<SettingsPage/>', () => {
     relations: [
       { type: 'ownedBy', targetRef: 'Group:alsomine' },
       { type: 'ownedBy', targetRef: 'Group:shared' },
-    ]
-  })
+    ],
+  });
 
   const team1 = {
-    teamTag: "my-group",
-    name: "My Group",
-    shortDescription: "Short Description",
-    fullDescription: "Full Description",
+    teamTag: 'my-group',
+    name: 'My Group',
+    shortDescription: 'Short Description',
+    fullDescription: 'Full Description',
     links: [
-      { name: "Link", type: "DOCUMENTATION", url: "URL", description: "description" }
+      {
+        name: 'Link',
+        type: 'DOCUMENTATION',
+        url: 'URL',
+        description: 'description',
+      },
     ],
-    slackChannels: [
-      { name: "Slack Channel", notificationsEnabled: true }
-    ],
-    emailMembers: [
-      { name: "Email Member", email: "emailmember@cortex.io" }
-    ],
+    slackChannels: [{ name: 'Slack Channel', notificationsEnabled: true }],
+    emailMembers: [{ name: 'Email Member', email: 'emailmember@cortex.io' }],
     additionalMembers: [
-      { name: "Additional Member", email: "additionalmember@cortex.io" }
-    ]
-  }
+      { name: 'Additional Member', email: 'additionalmember@cortex.io' },
+    ],
+  };
 
   const team2 = {
-    teamTag: "my-other-group",
-    name: "My Other Group"
-  }
+    teamTag: 'my-other-group',
+    name: 'My Other Group',
+  };
 
-  const teams = [team1, team2]
+  const teams = [team1, team2];
   const relationships = [
-    { parentTeamTag: team1.teamTag, childTeamTag: team2.teamTag }
-  ]
+    { parentTeamTag: team1.teamTag, childTeamTag: team2.teamTag },
+  ];
 
   const catalogApi: Partial<CatalogApi> = {
     async getEntities(_) {
       return {
-        items: [component1, component2]
-      }
-    }
-  }
+        items: [component1, component2],
+      };
+    },
+  };
+
+  const extension = {
+    'x-cortex-git': {
+      github: {
+        repository: 'my/repo',
+      },
+    },
+  };
+
+  const extensionApi: Partial<ExtensionApi> = {
+    async getCustomMappings() {
+      return [() => extension];
+    },
+
+    async getTeamOverrides(_) {
+      return {
+        teams,
+        relationships,
+      };
+    },
+  };
 
   const cortexApi = mock<CortexApi>();
 
-  it('should sync entities with custom mappings and group overrides', async () => {
-
-    const extension = {
-      'x-cortex-git': {
-        'github': {
-          repository: 'my/repo'
-        }
-      }
-    }
-
-    const extensionApi: Partial<ExtensionApi> = {
-      async getCustomMappings() {
-        return [() => extension]
-      },
-
-      async getTeamOverrides(_) {
-        return {
-          teams,
-          relationships,
-        }
-      }
-    }
-
-    const { clickButton, queryByLabelText } = renderWrapped(
-      <SettingsPage/>,
+  it('should submit entity sync with custom mappings and group overrides', async () => {
+    cortexApi.submitSyncTask.mockResolvedValue({ percentage: null });
+    const { clickButton, checkForText, queryByLabelText } = renderWrapped(
+      <SettingsPage />,
       cortexApi,
       {},
-      [catalogApiRef, catalogApi], [extensionApiRef, extensionApi]
+      [catalogApiRef, catalogApi],
+      [extensionApiRef, extensionApi],
     );
 
+    await checkForText(/Entities have never been synced before/);
+    expect(
+      await queryByLabelText('Cancel entity sync'),
+    ).not.toBeInTheDocument();
     await clickButton('Sync Entities');
-
     await waitFor(() =>
-      expect(queryByLabelText("Sync Entities")).toHaveAttribute('aria-busy', "false")
+      expect(queryByLabelText('Sync Entities')).toHaveAttribute(
+        'aria-busy',
+        'false',
+      ),
     );
-
+    await checkForText(/Entities have never been synced before/);
     const customMappingsCaptor = captor();
-    expect(cortexApi.syncEntities).toHaveBeenLastCalledWith(
+    expect(cortexApi.submitSyncTask).toHaveBeenLastCalledWith(
       [component1, component2],
       customMappingsCaptor,
-      { teams, relationships }
+      { teams, relationships },
     );
 
     expect(customMappingsCaptor.value).toHaveLength(1);
     expect(customMappingsCaptor.value[0]()).toBe(extension);
-  })
+  });
+
+  it('shows in progress entity sync', async () => {
+    cortexApi.getSyncTaskProgress.mockResolvedValue({ percentage: 0.7 });
+    const { checkForText, queryByLabelText } = renderWrapped(
+      <SettingsPage />,
+      cortexApi,
+      {},
+      [catalogApiRef, catalogApi],
+      [extensionApiRef, extensionApi],
+    );
+
+    await checkForText(/Entities have never been synced before/);
+    expect(await queryByLabelText(/Cancel entity sync/)).toBeVisible();
+  });
+
+  it('shows the last sync time', async () => {
+    cortexApi.getSyncTaskProgress.mockResolvedValue({ percentage: null });
+    cortexApi.getLastSyncTime.mockResolvedValue({
+      lastSynced: '2000-01-01T00:00:00',
+    });
+    const { checkForText, queryByLabelText } = renderWrapped(
+      <SettingsPage />,
+      cortexApi,
+      {},
+      [catalogApiRef, catalogApi],
+      [extensionApiRef, extensionApi],
+    );
+
+    await checkForText(/Last synced on Jan 1st 2000/);
+    expect(
+      await queryByLabelText('Cancel entity sync'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/SettingsPage/SettingsSyncCard.tsx
+++ b/src/components/SettingsPage/SettingsSyncCard.tsx
@@ -57,6 +57,7 @@ interface CancelSyncButtonProps {
 
 const CancelSyncButton: React.FC<CancelSyncButtonProps> = ({ cancelSync }) => {
   const [isCanceling, setIsCanceling] = useState(false);
+  
   return (
     <IconButton
       onClick={() => {

--- a/src/utils/HookUtils.ts
+++ b/src/utils/HookUtils.ts
@@ -16,9 +16,9 @@
 
 import { useEffect, useRef } from 'react';
 
-// Use null delay to end timer
 export const useInterval = (
   callback: (...args: any[]) => Promise<void>,
+  /** Use null delay to end timer */
   delay: number | null,
 ) => {
   const savedCallbackRef = useRef<(...args: any[]) => void>();

--- a/src/utils/HookUtils.ts
+++ b/src/utils/HookUtils.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef } from 'react';
+
+// Use null delay to end timer
+export const useInterval = (
+  callback: (...args: any[]) => Promise<void>,
+  delay: number | null,
+) => {
+  const savedCallbackRef = useRef<(...args: any[]) => void>();
+
+  useEffect(() => {
+    savedCallbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const handler = (...args: any[]) => savedCallbackRef.current!(...args);
+
+    if (delay !== null) {
+      const intervalId = setInterval(handler, delay);
+      return () => clearInterval(intervalId);
+    }
+    return undefined;
+  }, [delay]);
+};

--- a/src/utils/MathUtils.ts
+++ b/src/utils/MathUtils.ts
@@ -14,38 +14,36 @@
  * limitations under the License.
  */
 
-/**
- * Create new ExponentialBackoff
- * @param initialDelay Starting delay, in milliseconds
- * @param multiplier Multiplier for exponential growth (e.g. 2.0 would yield [1000 -> 2000 -> 4000])
- * @param maxDelay Ceiling for delay, subsequent advances will not increase delay
- * @param maxTries Max tries, after which delay will return null
- * @param numTries Starting point for number of tries
- */
-export type ExponentialBackoffOpts = {
+export type ExponentialBackoffOptions = {
+  /** Starting delay, in milliseconds */
   initialDelay: number;
-  multiplier: number;
   maxDelay?: number;
   maxTries?: number;
+  multiplier: number;
   numTries?: number;
 };
 
 /**
  * Immutable ExponentialBackoff helper
+ *
+ * @param multiplier Multiplier for exponential growth (e.g. 2.0 would yield [1000 -> 2000 -> 4000])
+ * @param maxDelay Ceiling for delay, subsequent advances will not increase delay
+ * @param maxTries Max tries, after which delay will return null
+ * @param numTries Starting point for number of tries
  */
 export class ExponentialBackoff {
-  multiplier;
+  currentDelay;
   maxDelay;
   maxTries;
-  currentDelay;
+  multiplier;
   numTries;
 
-  constructor(opts: ExponentialBackoffOpts) {
+  constructor(opts: ExponentialBackoffOptions) {
     const { initialDelay, multiplier, maxDelay, maxTries, numTries } = opts;
     this.currentDelay = initialDelay;
-    this.multiplier = multiplier;
     this.maxDelay = maxDelay ?? Number.MAX_SAFE_INTEGER;
     this.maxTries = maxTries;
+    this.multiplier = multiplier;
     this.numTries = numTries ?? 0;
   }
 

--- a/src/utils/MathUtils.ts
+++ b/src/utils/MathUtils.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Create new ExponentialBackoff
+ * @param initialDelay Starting delay, in milliseconds
+ * @param multiplier Multiplier for exponential growth (e.g. 2.0 would yield [1000 -> 2000 -> 4000])
+ * @param maxDelay Ceiling for delay, subsequent advances will not increase delay
+ * @param maxTries Max tries, after which delay will return null
+ * @param numTries Starting point for number of tries
+ */
+export type ExponentialBackoffOpts = {
+  initialDelay: number;
+  multiplier: number;
+  maxDelay?: number;
+  maxTries?: number;
+  numTries?: number;
+};
+
+/**
+ * Immutable ExponentialBackoff helper
+ */
+export class ExponentialBackoff {
+  multiplier;
+  maxDelay;
+  maxTries;
+  currentDelay;
+  numTries;
+
+  constructor(opts: ExponentialBackoffOpts) {
+    const { initialDelay, multiplier, maxDelay, maxTries, numTries } = opts;
+    this.currentDelay = initialDelay;
+    this.multiplier = multiplier;
+    this.maxDelay = maxDelay ?? Number.MAX_SAFE_INTEGER;
+    this.maxTries = maxTries;
+    this.numTries = numTries ?? 0;
+  }
+
+  delay(): number | null {
+    if (this.numTries === this.maxTries) {
+      return null;
+    }
+    return Math.min(this.currentDelay, this.maxDelay);
+  }
+
+  advance(): ExponentialBackoff {
+    let nextDelay = Math.min(
+      this.currentDelay * this.multiplier,
+      this.maxDelay ?? Number.MAX_SAFE_INTEGER,
+    );
+
+    return new ExponentialBackoff({
+      initialDelay: nextDelay,
+      multiplier: this.multiplier,
+      maxDelay: this.maxDelay,
+      maxTries: this.maxTries,
+      numTries: this.numTries + 1,
+    });
+  }
+}


### PR DESCRIPTION
## Change description

<img width="391" alt="Screenshot 2023-01-30 at 7 38 14 PM" src="https://user-images.githubusercontent.com/12239257/215629573-d1b950ce-c665-4663-9208-8be2db524aac.png">
<img width="383" alt="Screenshot 2023-01-31 at 2 50 51 PM" src="https://user-images.githubusercontent.com/12239257/215867494-396685e7-1f75-4c1b-80a3-ddf3f8e5b53f.png">
<img width="383" alt="Screenshot 2023-01-30 at 7 39 16 PM" src="https://user-images.githubusercontent.com/12239257/215629577-4829858b-4908-447a-929b-032f0d7372fa.png">
<img width="375" alt="image" src="https://user-images.githubusercontent.com/12239257/215867656-05eb17d5-65db-42c5-90c6-6b012d1e93ba.png">


Backstage entity sync is no longer synchronous. Clicking the button submits a job to the backend and shows an estimated progress bar. Users can only submit one sync at a time but they can see when the last sync occurred and cancel an ongoing sync.

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
