### PR TITLE
Support gzip in entity sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ cortex:
   frontendBaseUrl: ${CORTEX_FRONTEND_HOST_URL}
 ```
 
+11. (Optional) When performing manual entity sync in the settings page, you can choose to use gzip to compress the entities by updating `app-config.yaml` with the parameter `syncWithGzip`. You must also update the Backstage HTTP proxy to allow the `Content-Encoding` header. 
+
+```yaml
+cortex:
+   syncWithGzip: true
+```
+
+```yaml
+proxy:
+  '/cortex':
+    target: ${CORTEX_BACKEND_HOST_URL}
+    headers:
+      Authorization: ${CORTEX_TOKEN}
+    allowedHeaders:
+      - Content-Encoding
+```
+
 
 ## Advanced
 

--- a/config.d.ts
+++ b/config.d.ts
@@ -22,5 +22,11 @@ export interface Config {
      * @visibility frontend
      */
     frontendBaseUrl?: string;
+    /**
+     * The 'syncWithGzip' attribute. If true, the Cortex Backstage entity sync will use gzip.
+     * If not provided, the Cortex Backstage entity sync will not use gzip.
+     * @visibility frontend
+     */
+    syncWithGzip?: boolean;
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/api/CortexApi.ts
+++ b/src/api/CortexApi.ts
@@ -83,6 +83,7 @@ export interface CortexApi {
 
   submitEntitySync(
     entities: Entity[],
+    shouldGzipBody: boolean,
     customMappings?: CustomMapping[],
     teamOverrides?: TeamOverrides,
   ): Promise<EntitySyncProgress>;


### PR DESCRIPTION
## Change description

When performing manual entity sync in the settings page, you can choose to use gzip to compress the entities by updating `app-config.yaml` with the parameter `syncWithGzip`. By default, this behavior is _not_ enabled since it requires users to update proxy settings.

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
