### PR TITLE
CET-3001 - Metadata.name showing as entity name in Backstage reports instead of metadata.title

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/DefaultEntityLink/DefaultEntityRefLink.tsx
+++ b/src/components/DefaultEntityLink/DefaultEntityRefLink.tsx
@@ -19,20 +19,23 @@ import { defaultComponentRefContext } from '../../utils/ComponentUtils';
 import { Entity, CompoundEntityRef } from '@backstage/catalog-model';
 
 interface DefaultEntityRefLinkProps {
-  entityRef: Entity | CompoundEntityRef;
   children?: React.ReactNode;
+  entityRef: Entity | CompoundEntityRef;
+  title?: string;
 }
 
 export const DefaultEntityRefLink = ({
-  entityRef,
   children,
+  entityRef,
+  title,
 }: DefaultEntityRefLinkProps) => {
   return (
     <EntityRefLink
-      entityRef={entityRef}
-      defaultKind={defaultComponentRefContext.defaultKind}
       /* eslint-disable-next-line react/no-children-prop */
       children={children}
+      defaultKind={defaultComponentRefContext.defaultKind}
+      entityRef={entityRef}
+      title={title}
     />
   );
 };

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
@@ -30,7 +30,7 @@ import { InitiativeTableCard } from './InitiativeTableCard';
 import { InitiativeFilterCard } from './InitiativeFilterCard';
 import { Predicate } from '../../../utils/types';
 import { InitiativeStatsCard } from './InitiativeStatsCard';
-import {useEntitiesByTag} from "../../../utils/hooks";
+import { useEntitiesByTag } from '../../../utils/hooks';
 
 export const InitiativeDetailsPage = () => {
   const { id: initiativeId } = useRouteRefParams(initiativeRouteRef);

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
@@ -30,6 +30,7 @@ import { InitiativeTableCard } from './InitiativeTableCard';
 import { InitiativeFilterCard } from './InitiativeFilterCard';
 import { Predicate } from '../../../utils/types';
 import { InitiativeStatsCard } from './InitiativeStatsCard';
+import {useEntitiesByTag} from "../../../utils/hooks";
 
 export const InitiativeDetailsPage = () => {
   const { id: initiativeId } = useRouteRefParams(initiativeRouteRef);
@@ -48,6 +49,8 @@ export const InitiativeDetailsPage = () => {
     ]);
   }, []);
 
+  const { entitiesByTag, loading: loadingEntities } = useEntitiesByTag();
+
   const [initiative, actionItems] = value ?? [undefined, undefined];
 
   const filteredComponentRefs = useMemo(() => {
@@ -56,7 +59,7 @@ export const InitiativeDetailsPage = () => {
     );
   }, [initiative, filter]);
 
-  if (loading) {
+  if (loading || loadingEntities) {
     return <Progress />;
   }
 
@@ -87,9 +90,10 @@ export const InitiativeDetailsPage = () => {
             filter={filter}
           />
           <InitiativeTableCard
-            componentRefs={filteredComponentRefs}
-            numRules={initiative.emphasizedRules.length}
             actionItems={actionItems}
+            componentRefs={filteredComponentRefs}
+            entitiesByTag={entitiesByTag}
+            numRules={initiative.emphasizedRules.length}
           />
         </Grid>
       </Grid>

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/FailingComponentsTable.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/FailingComponentsTable.tsx
@@ -29,6 +29,8 @@ import { FailingComponentsTableRow } from './FailingComponentsTableRow';
 import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
 import { humanizeAnyEntityRef } from '../../../../utils/types';
 import { Box } from '@material-ui/core';
+import {StringIndexable} from "../../../ReportsPage/HeatmapPage/HeatmapUtils";
+import {HomepageEntity} from "../../../../api/userInsightTypes";
 
 const columns: TableColumn[] = [
   {
@@ -37,12 +39,14 @@ const columns: TableColumn[] = [
       componentRef?: string;
       numRules?: number;
       actionItems?: InitiativeActionItem[];
+      title?: string;
     }) => {
       return (
         <FailingComponentsTableRow
           componentRef={data.componentRef ?? ''}
           actionItems={data.actionItems ?? []}
           numRules={data.numRules ?? 0}
+          title={data.title}
         />
       );
     },
@@ -57,12 +61,14 @@ const columns: TableColumn[] = [
 interface FailingComponentsTableProps {
   actionItems: InitiativeActionItem[];
   defaultPageSize?: number;
+  entitiesByTag: StringIndexable<HomepageEntity>;
   numRules: number;
 }
 
 export const FailingComponentsTable = ({
   actionItems,
   defaultPageSize = 15,
+  entitiesByTag,
   numRules,
 }: FailingComponentsTableProps) => {
   const classes = useDetailCardStyles();
@@ -75,7 +81,7 @@ export const FailingComponentsTable = ({
   const data = useMemo(() => {
     return Object.keys(failingComponents)
       .map(componentRef => {
-        const serviceName = humanizeAnyEntityRef(
+        const serviceName =  humanizeAnyEntityRef(
           componentRef,
           defaultComponentRefContext,
         );
@@ -84,6 +90,7 @@ export const FailingComponentsTable = ({
           componentRef,
           numRules,
           serviceName,
+          title: entitiesByTag[componentRef]?.name,
         };
       })
       .sort((left, right) => left.actionItems.length - right.actionItems.length)

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/FailingComponentsTable.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/FailingComponentsTable.tsx
@@ -29,8 +29,8 @@ import { FailingComponentsTableRow } from './FailingComponentsTableRow';
 import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
 import { humanizeAnyEntityRef } from '../../../../utils/types';
 import { Box } from '@material-ui/core';
-import {StringIndexable} from "../../../ReportsPage/HeatmapPage/HeatmapUtils";
-import {HomepageEntity} from "../../../../api/userInsightTypes";
+import { StringIndexable } from '../../../ReportsPage/HeatmapPage/HeatmapUtils';
+import { HomepageEntity } from '../../../../api/userInsightTypes';
 
 const columns: TableColumn[] = [
   {
@@ -81,7 +81,7 @@ export const FailingComponentsTable = ({
   const data = useMemo(() => {
     return Object.keys(failingComponents)
       .map(componentRef => {
-        const serviceName =  humanizeAnyEntityRef(
+        const serviceName = humanizeAnyEntityRef(
           componentRef,
           defaultComponentRefContext,
         );
@@ -95,7 +95,7 @@ export const FailingComponentsTable = ({
       })
       .sort((left, right) => left.actionItems.length - right.actionItems.length)
       .sort((left, right) => left.serviceName.localeCompare(right.serviceName));
-  }, [failingComponents, numRules]);
+  }, [entitiesByTag, failingComponents, numRules]);
 
   const showPagination = useMemo(() => {
     return Object.keys(failingComponents).length > defaultPageSize;

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/FailingComponentsTableRow.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/FailingComponentsTableRow.tsx
@@ -26,15 +26,17 @@ import { ScorecardResultDetails } from '../../../Scorecards/ScorecardDetailsPage
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 
 interface FailingComponentsTableRowProps {
-  componentRef: string;
   actionItems: InitiativeActionItem[];
+  componentRef: string;
   numRules: number;
+  title?: string;
 }
 
 export const FailingComponentsTableRow = ({
-  componentRef,
   actionItems,
+  componentRef,
   numRules,
+  title,
 }: FailingComponentsTableRowProps) => {
   const [isOpen, setOpen] = useState(false);
   const entityName = parseEntityRef(componentRef, defaultComponentRefContext);
@@ -58,7 +60,7 @@ export const FailingComponentsTableRow = ({
         </Box>
 
         <Box paddingLeft={2}>
-          <DefaultEntityRefLink entityRef={entityName} />
+          <DefaultEntityRefLink entityRef={entityName} title={title} />
         </Box>
       </Box>
 

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/InitiativeTableCard.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/InitiativeTableCard.tsx
@@ -19,8 +19,8 @@ import { useDetailCardStyles } from '../../../../styles/styles';
 import { EmptyState, InfoCard } from '@backstage/core-components';
 import { FailingComponentsTable } from './FailingComponentsTable';
 import { PassingComponentsTable } from './PassingComponentsTable';
-import {StringIndexable} from "../../../ReportsPage/HeatmapPage/HeatmapUtils";
-import {HomepageEntity} from "../../../../api/userInsightTypes";
+import { StringIndexable } from '../../../ReportsPage/HeatmapPage/HeatmapUtils';
+import { HomepageEntity } from '../../../../api/userInsightTypes';
 
 interface InitiativeTableProps {
   actionItems: InitiativeActionItem[];
@@ -62,7 +62,11 @@ export const InitiativeTableCard = ({
         entitiesByTag={entitiesByTag}
         numRules={numRules}
       />
-      <PassingComponentsTable componentRefs={passing} entitiesByTag={entitiesByTag} numRules={numRules} />
+      <PassingComponentsTable
+        componentRefs={passing}
+        entitiesByTag={entitiesByTag}
+        numRules={numRules}
+      />
     </>
   );
 };

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/InitiativeTableCard.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/InitiativeTableCard.tsx
@@ -19,17 +19,21 @@ import { useDetailCardStyles } from '../../../../styles/styles';
 import { EmptyState, InfoCard } from '@backstage/core-components';
 import { FailingComponentsTable } from './FailingComponentsTable';
 import { PassingComponentsTable } from './PassingComponentsTable';
+import {StringIndexable} from "../../../ReportsPage/HeatmapPage/HeatmapUtils";
+import {HomepageEntity} from "../../../../api/userInsightTypes";
 
 interface InitiativeTableProps {
-  componentRefs: string[];
-  numRules: number;
   actionItems: InitiativeActionItem[];
+  componentRefs: string[];
+  entitiesByTag: StringIndexable<HomepageEntity>;
+  numRules: number;
 }
 
 export const InitiativeTableCard = ({
-  componentRefs,
-  numRules,
   actionItems,
+  componentRefs,
+  entitiesByTag,
+  numRules,
 }: InitiativeTableProps) => {
   const classes = useDetailCardStyles();
 
@@ -55,9 +59,10 @@ export const InitiativeTableCard = ({
     <>
       <FailingComponentsTable
         actionItems={filteredActionItems}
+        entitiesByTag={entitiesByTag}
         numRules={numRules}
       />
-      <PassingComponentsTable componentRefs={passing} numRules={numRules} />
+      <PassingComponentsTable componentRefs={passing} entitiesByTag={entitiesByTag} numRules={numRules} />
     </>
   );
 };

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/PassingComponentsTable.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/PassingComponentsTable.tsx
@@ -31,6 +31,8 @@ import { Gauge } from '../../../Gauge';
 import { DefaultEntityRefLink } from '../../../DefaultEntityLink';
 import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
 import { humanizeAnyEntityRef } from '../../../../utils/types';
+import {HomepageEntity} from "../../../../api/userInsightTypes";
+import {StringIndexable} from "../../../ReportsPage/HeatmapPage/HeatmapUtils";
 
 const columns: TableColumn[] = [
   {
@@ -39,6 +41,7 @@ const columns: TableColumn[] = [
       componentRef?: string;
       numRules?: number;
       serviceName?: string;
+      title?: string;
     }) => {
       return (
         <Box display="flex" flexDirection="row" alignItems="center">
@@ -62,6 +65,7 @@ const columns: TableColumn[] = [
                 data.componentRef ?? '',
                 defaultComponentRefContext,
               )}
+              title={data.title}
             />
           </Box>
         </Box>
@@ -78,13 +82,15 @@ const columns: TableColumn[] = [
 interface PassingComponentsTableProps {
   componentRefs: string[];
   defaultPageSize?: number;
+  entitiesByTag: StringIndexable<HomepageEntity>;
   numRules: number;
 }
 
 export const PassingComponentsTable = ({
   componentRefs,
-  numRules,
   defaultPageSize = 15,
+  entitiesByTag,
+  numRules,
 }: PassingComponentsTableProps) => {
   const classes = useDetailCardStyles();
 
@@ -99,14 +105,7 @@ export const PassingComponentsTable = ({
           componentRef,
           numRules,
           serviceName, // for custom filtering
-          title: (
-            <DefaultEntityRefLink
-              entityRef={parseEntityRef(
-                componentRef,
-                defaultComponentRefContext,
-              )}
-            />
-          ),
+          title: entitiesByTag[componentRef]?.name,
           toggle: null,
         };
       })

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/PassingComponentsTable.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeTableCard/PassingComponentsTable.tsx
@@ -31,8 +31,8 @@ import { Gauge } from '../../../Gauge';
 import { DefaultEntityRefLink } from '../../../DefaultEntityLink';
 import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
 import { humanizeAnyEntityRef } from '../../../../utils/types';
-import {HomepageEntity} from "../../../../api/userInsightTypes";
-import {StringIndexable} from "../../../ReportsPage/HeatmapPage/HeatmapUtils";
+import { HomepageEntity } from '../../../../api/userInsightTypes';
+import { StringIndexable } from '../../../ReportsPage/HeatmapPage/HeatmapUtils';
 
 const columns: TableColumn[] = [
   {
@@ -110,7 +110,7 @@ export const PassingComponentsTable = ({
         };
       })
       .sort((left, right) => left.serviceName.localeCompare(right.serviceName));
-  }, [componentRefs, numRules]);
+  }, [componentRefs, entitiesByTag, numRules]);
 
   const showPagination = useMemo(
     () => componentRefs.length > defaultPageSize,

--- a/src/components/ReportsPage/AllScorecardsPage/AllScorecardsHeatmap.tsx
+++ b/src/components/ReportsPage/AllScorecardsPage/AllScorecardsHeatmap.tsx
@@ -18,9 +18,9 @@ import { Progress, WarningPanel } from '@backstage/core-components';
 import { useCortexApi } from '../../../utils/hooks';
 import { GroupByOption } from '../../../api/types';
 import { AllScorecardsHeatmapTable } from '../HeatmapPage/Tables/AllScorecardHeatmapTable';
-import {StringIndexable} from "../HeatmapPage/HeatmapUtils";
-import {HomepageEntity} from "../../../api/userInsightTypes";
-import {isNil, keyBy} from "lodash";
+import { StringIndexable } from '../HeatmapPage/HeatmapUtils';
+import { HomepageEntity } from '../../../api/userInsightTypes';
+import { isNil, keyBy } from 'lodash';
 
 interface AllScorecardsHeatmapProps {
   groupBy: GroupByOption;
@@ -51,17 +51,18 @@ export const AllScorecardsHeatmap = ({
     );
   }, [scorecards]);
 
-
   const { value: entities, loading: loadingEntities } = useCortexApi(
     api => api.getCatalogEntities(),
     [],
   );
 
   const entitiesByTag: StringIndexable<HomepageEntity> = useMemo(
-    () => !isNil(entities) && !isNil(entities.entities) ? keyBy(Object.values(entities.entities), (entity) => entity.codeTag) : {},
-    [entities]
+    () =>
+      !isNil(entities) && !isNil(entities.entities)
+        ? keyBy(Object.values(entities.entities), entity => entity.codeTag)
+        : {},
+    [entities],
   );
-
 
   if (loading || loadingEntities) {
     return <Progress />;

--- a/src/components/ReportsPage/AllScorecardsPage/AllScorecardsHeatmap.tsx
+++ b/src/components/ReportsPage/AllScorecardsPage/AllScorecardsHeatmap.tsx
@@ -18,6 +18,9 @@ import { Progress, WarningPanel } from '@backstage/core-components';
 import { useCortexApi } from '../../../utils/hooks';
 import { GroupByOption } from '../../../api/types';
 import { AllScorecardsHeatmapTable } from '../HeatmapPage/Tables/AllScorecardHeatmapTable';
+import {StringIndexable} from "../HeatmapPage/HeatmapUtils";
+import {HomepageEntity} from "../../../api/userInsightTypes";
+import {isNil, keyBy} from "lodash";
 
 interface AllScorecardsHeatmapProps {
   groupBy: GroupByOption;
@@ -48,7 +51,19 @@ export const AllScorecardsHeatmap = ({
     );
   }, [scorecards]);
 
-  if (loading) {
+
+  const { value: entities, loading: loadingEntities } = useCortexApi(
+    api => api.getCatalogEntities(),
+    [],
+  );
+
+  const entitiesByTag: StringIndexable<HomepageEntity> = useMemo(
+    () => !isNil(entities) && !isNil(entities.entities) ? keyBy(Object.values(entities.entities), (entity) => entity.codeTag) : {},
+    [entities]
+  );
+
+
+  if (loading || loadingEntities) {
     return <Progress />;
   }
 
@@ -74,6 +89,7 @@ export const AllScorecardsHeatmap = ({
 
   return (
     <AllScorecardsHeatmapTable
+      entitiesByTag={entitiesByTag}
       groupBy={groupBy}
       scorecardNames={scorecardNames}
       serviceScores={serviceScores}

--- a/src/components/ReportsPage/AllScorecardsPage/AllScorecardsHeatmap.tsx
+++ b/src/components/ReportsPage/AllScorecardsPage/AllScorecardsHeatmap.tsx
@@ -15,12 +15,9 @@
  */
 import React, { useMemo } from 'react';
 import { Progress, WarningPanel } from '@backstage/core-components';
-import { useCortexApi } from '../../../utils/hooks';
+import { useCortexApi, useEntitiesByTag } from '../../../utils/hooks';
 import { GroupByOption } from '../../../api/types';
 import { AllScorecardsHeatmapTable } from '../HeatmapPage/Tables/AllScorecardHeatmapTable';
-import { StringIndexable } from '../HeatmapPage/HeatmapUtils';
-import { HomepageEntity } from '../../../api/userInsightTypes';
-import { isNil, keyBy } from 'lodash';
 
 interface AllScorecardsHeatmapProps {
   groupBy: GroupByOption;
@@ -51,18 +48,7 @@ export const AllScorecardsHeatmap = ({
     );
   }, [scorecards]);
 
-  const { value: entities, loading: loadingEntities } = useCortexApi(
-    api => api.getCatalogEntities(),
-    [],
-  );
-
-  const entitiesByTag: StringIndexable<HomepageEntity> = useMemo(
-    () =>
-      !isNil(entities) && !isNil(entities.entities)
-        ? keyBy(Object.values(entities.entities), entity => entity.codeTag)
-        : {},
-    [entities],
-  );
+  const { entitiesByTag, loading: loadingEntities } = useEntitiesByTag();
 
   if (loading || loadingEntities) {
     return <Progress />;

--- a/src/components/ReportsPage/HeatmapPage/SingleScorecardHeatmap.tsx
+++ b/src/components/ReportsPage/HeatmapPage/SingleScorecardHeatmap.tsx
@@ -13,14 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Progress, WarningPanel } from '@backstage/core-components';
-import { useCortexApi } from '../../../utils/hooks';
+import { useCortexApi, useEntitiesByTag } from '../../../utils/hooks';
 import { GroupByOption, HeaderType } from '../../../api/types';
 import { SingleScorecardHeatmapTable } from './Tables/SingleScorecardHeatmapTable';
-import { isNil, keyBy } from 'lodash';
-import { StringIndexable } from './HeatmapUtils';
-import { HomepageEntity } from '../../../api/userInsightTypes';
 
 interface SingleScorecardHeatmapProps {
   scorecardId: number;
@@ -43,19 +40,7 @@ export const SingleScorecardHeatmap = ({
     api => api.getScorecardLadders(scorecardId),
     [scorecardId],
   );
-
-  const { value: entities, loading: loadingEntities } = useCortexApi(
-    api => api.getCatalogEntities(),
-    [],
-  );
-
-  const entitiesByTag: StringIndexable<HomepageEntity> = useMemo(
-    () =>
-      !isNil(entities) && !isNil(entities.entities)
-        ? keyBy(Object.values(entities.entities), entity => entity.codeTag)
-        : {},
-    [entities],
-  );
+  const { entitiesByTag, loading: loadingEntities } = useEntitiesByTag();
 
   if (loadingScores || loadingLadders || loadingEntities) {
     return <Progress />;

--- a/src/components/ReportsPage/HeatmapPage/SingleScorecardHeatmap.tsx
+++ b/src/components/ReportsPage/HeatmapPage/SingleScorecardHeatmap.tsx
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, {useMemo} from 'react';
 import { Progress, WarningPanel } from '@backstage/core-components';
 import { useCortexApi } from '../../../utils/hooks';
 import { GroupByOption, HeaderType } from '../../../api/types';
 import { SingleScorecardHeatmapTable } from './Tables/SingleScorecardHeatmapTable';
+import {isNil, keyBy} from "lodash";
+import {StringIndexable} from "./HeatmapUtils";
+import {HomepageEntity} from "../../../api/userInsightTypes";
 
 interface SingleScorecardHeatmapProps {
   scorecardId: number;
@@ -41,7 +44,17 @@ export const SingleScorecardHeatmap = ({
     [scorecardId],
   );
 
-  if (loadingScores || loadingLadders) {
+  const { value: entities, loading: loadingEntities } = useCortexApi(
+    api => api.getCatalogEntities(),
+    [],
+  );
+
+  const entitiesByTag: StringIndexable<HomepageEntity> = useMemo(
+    () => !isNil(entities) && !isNil(entities.entities) ? keyBy(Object.values(entities.entities), (entity) => entity.codeTag) : {},
+    [entities]
+  );
+
+  if (loadingScores || loadingLadders || loadingEntities) {
     return <Progress />;
   }
 
@@ -64,10 +77,11 @@ export const SingleScorecardHeatmap = ({
 
   return (
     <SingleScorecardHeatmapTable
+      entitiesByTag={entitiesByTag}
       groupBy={groupBy}
       headerType={headerType}
-      scores={scores}
       ladder={ladders?.[0]}
+      scores={scores}
     />
   );
 };

--- a/src/components/ReportsPage/HeatmapPage/SingleScorecardHeatmap.tsx
+++ b/src/components/ReportsPage/HeatmapPage/SingleScorecardHeatmap.tsx
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, {useMemo} from 'react';
+import React, { useMemo } from 'react';
 import { Progress, WarningPanel } from '@backstage/core-components';
 import { useCortexApi } from '../../../utils/hooks';
 import { GroupByOption, HeaderType } from '../../../api/types';
 import { SingleScorecardHeatmapTable } from './Tables/SingleScorecardHeatmapTable';
-import {isNil, keyBy} from "lodash";
-import {StringIndexable} from "./HeatmapUtils";
-import {HomepageEntity} from "../../../api/userInsightTypes";
+import { isNil, keyBy } from 'lodash';
+import { StringIndexable } from './HeatmapUtils';
+import { HomepageEntity } from '../../../api/userInsightTypes';
 
 interface SingleScorecardHeatmapProps {
   scorecardId: number;
@@ -50,8 +50,11 @@ export const SingleScorecardHeatmap = ({
   );
 
   const entitiesByTag: StringIndexable<HomepageEntity> = useMemo(
-    () => !isNil(entities) && !isNil(entities.entities) ? keyBy(Object.values(entities.entities), (entity) => entity.codeTag) : {},
-    [entities]
+    () =>
+      !isNil(entities) && !isNil(entities.entities)
+        ? keyBy(Object.values(entities.entities), entity => entity.codeTag)
+        : {},
+    [entities],
   );
 
   if (loadingScores || loadingLadders || loadingEntities) {

--- a/src/components/ReportsPage/HeatmapPage/Tables/AllScorecardHeatmapTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/AllScorecardHeatmapTable.tsx
@@ -21,19 +21,22 @@ import { parseEntityRef } from '@backstage/catalog-model';
 
 import { HeatmapTableHeader } from './HeatmapTableHeader';
 import { HeatmapCell } from '../HeatmapCell';
-import { getFormattedScorecardScores } from '../HeatmapUtils';
+import {getFormattedScorecardScores, StringIndexable} from '../HeatmapUtils';
 import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
 import { filterNotUndefined } from '../../../../utils/collections';
 
 import { GroupByOption, ScoresByIdentifier } from '../../../../api/types';
+import {HomepageEntity} from "../../../../api/userInsightTypes";
 
 interface AllScorecardsHeatmapTableProps {
+  entitiesByTag: StringIndexable<HomepageEntity>;
   groupBy: GroupByOption;
   scorecardNames: string[];
   serviceScores: ScoresByIdentifier[];
 }
 
 export const AllScorecardsHeatmapTable = ({
+  entitiesByTag,
   groupBy,
   scorecardNames,
   serviceScores,
@@ -78,6 +81,7 @@ export const AllScorecardsHeatmapTable = ({
                       groupScore.identifier!!,
                       defaultComponentRefContext,
                     )}
+                    title={entitiesByTag[groupScore.identifier!!]?.name}
                   />
                 )}
               </TableCell>

--- a/src/components/ReportsPage/HeatmapPage/Tables/AllScorecardHeatmapTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/AllScorecardHeatmapTable.tsx
@@ -21,12 +21,12 @@ import { parseEntityRef } from '@backstage/catalog-model';
 
 import { HeatmapTableHeader } from './HeatmapTableHeader';
 import { HeatmapCell } from '../HeatmapCell';
-import {getFormattedScorecardScores, StringIndexable} from '../HeatmapUtils';
+import { getFormattedScorecardScores, StringIndexable } from '../HeatmapUtils';
 import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
 import { filterNotUndefined } from '../../../../utils/collections';
 
 import { GroupByOption, ScoresByIdentifier } from '../../../../api/types';
-import {HomepageEntity} from "../../../../api/userInsightTypes";
+import { HomepageEntity } from '../../../../api/userInsightTypes';
 
 interface AllScorecardsHeatmapTableProps {
   entitiesByTag: StringIndexable<HomepageEntity>;

--- a/src/components/ReportsPage/HeatmapPage/Tables/HeatmapTableByService.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/HeatmapTableByService.tsx
@@ -26,7 +26,7 @@ import { HeatmapCell } from '../HeatmapCell';
 import { getAverageRuleScores, StringIndexable } from '../HeatmapUtils';
 import { mean as _average } from 'lodash';
 import { HeatmapTableHeader } from './HeatmapTableHeader';
-import {HomepageEntity} from "../../../../api/userInsightTypes";
+import { HomepageEntity } from '../../../../api/userInsightTypes';
 
 interface HeatmapTableByServiceProps {
   data: StringIndexable<ScorecardServiceScore[]>;

--- a/src/components/ReportsPage/HeatmapPage/Tables/HeatmapTableByService.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/HeatmapTableByService.tsx
@@ -26,15 +26,18 @@ import { HeatmapCell } from '../HeatmapCell';
 import { getAverageRuleScores, StringIndexable } from '../HeatmapUtils';
 import { mean as _average } from 'lodash';
 import { HeatmapTableHeader } from './HeatmapTableHeader';
+import {HomepageEntity} from "../../../../api/userInsightTypes";
 
 interface HeatmapTableByServiceProps {
-  rules: string[];
   data: StringIndexable<ScorecardServiceScore[]>;
+  entitiesByTag: StringIndexable<HomepageEntity>;
+  rules: string[];
 }
 
 export const HeatmapTableByService = ({
-  rules,
   data,
+  entitiesByTag,
+  rules,
 }: HeatmapTableByServiceProps) => {
   const headers = ['Service Details', 'Score', ...rules];
 
@@ -57,6 +60,7 @@ export const HeatmapTableByService = ({
                     firstScore.componentRef,
                     defaultComponentRefContext,
                   )}
+                  title={entitiesByTag[firstScore.componentRef]?.name}
                 />
               </TableCell>
               <HeatmapCell score={averageScorePercentage} />

--- a/src/components/ReportsPage/HeatmapPage/Tables/LevelsDrivenTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/LevelsDrivenTable.tsx
@@ -33,17 +33,20 @@ import {
 } from '../HeatmapUtils';
 
 import { GroupByOption, ScorecardServiceScore } from '../../../../api/types';
+import {HomepageEntity} from "../../../../api/userInsightTypes";
 
 interface LevelsDrivenTableProps {
-  levels: string[];
-  groupBy: GroupByOption;
   data: StringIndexable<ScorecardServiceScore[]>;
+  entititesByTag: StringIndexable<HomepageEntity>;
+  groupBy: GroupByOption;
+  levels: string[];
 }
 
 export const LevelsDrivenTable = ({
-  levels,
-  groupBy,
   data,
+  entititesByTag,
+  groupBy,
+  levels,
 }: LevelsDrivenTableProps) => {
   const notGroupedByServices = groupBy !== GroupByOption.SERVICE;
   const headers = [
@@ -76,6 +79,7 @@ export const LevelsDrivenTable = ({
                       firstScore.componentRef,
                       defaultComponentRefContext,
                     )}
+                    title={entititesByTag[firstScore.componentRef]?.name}
                   />
                 </TableCell>
               )}

--- a/src/components/ReportsPage/HeatmapPage/Tables/LevelsDrivenTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/LevelsDrivenTable.tsx
@@ -33,7 +33,7 @@ import {
 } from '../HeatmapUtils';
 
 import { GroupByOption, ScorecardServiceScore } from '../../../../api/types';
-import {HomepageEntity} from "../../../../api/userInsightTypes";
+import { HomepageEntity } from '../../../../api/userInsightTypes';
 
 interface LevelsDrivenTableProps {
   data: StringIndexable<ScorecardServiceScore[]>;

--- a/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
@@ -23,7 +23,7 @@ import { HeatmapTableByService } from './HeatmapTableByService';
 import { LevelsDrivenTable } from './LevelsDrivenTable';
 import {
   getScorecardServiceScoresByGroupByOption,
-  getSortedRuleNames,
+  getSortedRuleNames, StringIndexable,
 } from '../HeatmapUtils';
 import { getSortedLadderLevelNames } from '../../../../utils/ScorecardLadderUtils';
 
@@ -33,19 +33,22 @@ import {
   ScorecardLadder,
   ScorecardServiceScore,
 } from '../../../../api/types';
+import {HomepageEntity} from "../../../../api/userInsightTypes";
 
 interface SingleScorecardHeatmapTableProps {
+  entitiesByTag: StringIndexable<HomepageEntity>;
   groupBy: GroupByOption;
   headerType: HeaderType;
-  scores: ScorecardServiceScore[];
   ladder: ScorecardLadder | undefined;
+  scores: ScorecardServiceScore[];
 }
 
 export const SingleScorecardHeatmapTable = ({
+  entitiesByTag,
   groupBy,
   headerType,
-  scores,
   ladder,
+  scores,
 }: SingleScorecardHeatmapTableProps) => {
   const levelsDriven = headerType === HeaderType.LEVELS;
   const headers = useMemo(
@@ -70,14 +73,14 @@ export const SingleScorecardHeatmapTable = ({
       );
     } else {
       return (
-        <LevelsDrivenTable levels={headers} groupBy={groupBy} data={data} />
+        <LevelsDrivenTable data={data} entititesByTag={entitiesByTag} groupBy={groupBy} levels={headers} />
       );
     }
   }
 
   switch (groupBy) {
     case GroupByOption.SERVICE:
-      return <HeatmapTableByService rules={headers} data={data} />;
+      return <HeatmapTableByService data={data} entitiesByTag={entitiesByTag} rules={headers} />;
     case GroupByOption.SERVICE_GROUP:
       return (
         <HeatmapTableByGroup

--- a/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
@@ -23,7 +23,8 @@ import { HeatmapTableByService } from './HeatmapTableByService';
 import { LevelsDrivenTable } from './LevelsDrivenTable';
 import {
   getScorecardServiceScoresByGroupByOption,
-  getSortedRuleNames, StringIndexable,
+  getSortedRuleNames,
+  StringIndexable,
 } from '../HeatmapUtils';
 import { getSortedLadderLevelNames } from '../../../../utils/ScorecardLadderUtils';
 
@@ -33,7 +34,7 @@ import {
   ScorecardLadder,
   ScorecardServiceScore,
 } from '../../../../api/types';
-import {HomepageEntity} from "../../../../api/userInsightTypes";
+import { HomepageEntity } from '../../../../api/userInsightTypes';
 
 interface SingleScorecardHeatmapTableProps {
   entitiesByTag: StringIndexable<HomepageEntity>;
@@ -73,14 +74,25 @@ export const SingleScorecardHeatmapTable = ({
       );
     } else {
       return (
-        <LevelsDrivenTable data={data} entititesByTag={entitiesByTag} groupBy={groupBy} levels={headers} />
+        <LevelsDrivenTable
+          data={data}
+          entititesByTag={entitiesByTag}
+          groupBy={groupBy}
+          levels={headers}
+        />
       );
     }
   }
 
   switch (groupBy) {
     case GroupByOption.SERVICE:
-      return <HeatmapTableByService data={data} entitiesByTag={entitiesByTag} rules={headers} />;
+      return (
+        <HeatmapTableByService
+          data={data}
+          entitiesByTag={entitiesByTag}
+          rules={headers}
+        />
+      );
     case GroupByOption.SERVICE_GROUP:
       return (
         <HeatmapTableByGroup

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetails.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetails.tsx
@@ -28,18 +28,22 @@ import { ScorecardsTableCard } from './ScorecardsTableCard';
 import { Predicate } from '../../../utils/types';
 import { ScorecardLaddersCard } from './ScorecardLaddersCard';
 import { ScorecardStatsCard } from './ScorecardStatsCard';
+import {StringIndexable} from "../../ReportsPage/HeatmapPage/HeatmapUtils";
+import {HomepageEntity} from "../../../api/userInsightTypes";
 
 export type ScorecardServiceScoreFilter = Predicate<ScorecardServiceScore>;
 
 interface ScorecardDetailsProps {
-  scorecard: Scorecard;
+  entitiesByTag: StringIndexable<HomepageEntity>;
   ladder: ScorecardLadder | undefined;
+  scorecard: Scorecard;
   scores: ScorecardServiceScore[];
 }
 
 export const ScorecardDetails = ({
-  scorecard,
+  entitiesByTag,
   ladder,
+  scorecard,
   scores,
 }: ScorecardDetailsProps) => {
   // Have to store lambda of lambda for React to not eagerly invoke
@@ -67,6 +71,7 @@ export const ScorecardDetails = ({
         <Grid item lg={8} xs={12}>
           <ScorecardStatsCard scores={filteredScores} />
           <ScorecardsTableCard
+            entitiesByTag={entitiesByTag}
             scorecardId={scorecard.id}
             scores={filteredScores}
           />

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetails.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetails.tsx
@@ -28,8 +28,8 @@ import { ScorecardsTableCard } from './ScorecardsTableCard';
 import { Predicate } from '../../../utils/types';
 import { ScorecardLaddersCard } from './ScorecardLaddersCard';
 import { ScorecardStatsCard } from './ScorecardStatsCard';
-import {StringIndexable} from "../../ReportsPage/HeatmapPage/HeatmapUtils";
-import {HomepageEntity} from "../../../api/userInsightTypes";
+import { StringIndexable } from '../../ReportsPage/HeatmapPage/HeatmapUtils';
+import { HomepageEntity } from '../../../api/userInsightTypes';
 
 export type ScorecardServiceScoreFilter = Predicate<ScorecardServiceScore>;
 

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetailsPage.test.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetailsPage.test.tsx
@@ -33,6 +33,7 @@ import {
 import { EntityFilterGroup } from '../../../filters';
 import { extensionApiRef } from '../../../api/ExtensionApi';
 import { act } from 'react-dom/test-utils';
+import { HomepageEntityResponse } from '../../../api/userInsightTypes';
 
 describe('ScorecardDetailsPage', () => {
   const emptyExtensionApi: ExtensionApi = {
@@ -88,14 +89,39 @@ describe('ScorecardDetailsPage', () => {
     async getScorecardScores(_: number): Promise<ScorecardServiceScore[]> {
       return [
         Fixtures.scorecardServiceScore({
-          componentRef: 'foo',
+          componentRef: 'foo-tag',
           scorePercentage: 0.5,
         }),
         Fixtures.scorecardServiceScore({
-          componentRef: 'bar',
+          componentRef: 'bar-tag',
           scorePercentage: 0.7,
         }),
       ];
+    },
+
+    async getCatalogEntities(): Promise<HomepageEntityResponse> {
+      return {
+        entities: [
+          {
+            codeTag: 'foo-tag',
+            groupNames: [],
+            id: 1,
+            name: 'foo',
+            serviceGroupTags: [],
+            serviceOwnerEmails: [],
+            type: 'service',
+          },
+          {
+            codeTag: 'bar-tag',
+            groupNames: [],
+            id: 2,
+            name: 'bar',
+            serviceGroupTags: [],
+            serviceOwnerEmails: [],
+            type: 'service',
+          },
+        ],
+      };
     },
   };
 
@@ -105,7 +131,7 @@ describe('ScorecardDetailsPage', () => {
         items: [
           Fixtures.entity({
             kind: 'Component',
-            metadata: Fixtures.entityMeta({ name: 'foo' }),
+            metadata: Fixtures.entityMeta({ name: 'foo-tag' }),
             relations: [
               { type: 'ownedBy', targetRef: 'Group:shared' },
               { type: 'ownedBy', targetRef: 'Group:mine' },
@@ -113,7 +139,7 @@ describe('ScorecardDetailsPage', () => {
           }),
           Fixtures.entity({
             kind: 'Component',
-            metadata: Fixtures.entityMeta({ name: 'bar' }),
+            metadata: Fixtures.entityMeta({ name: 'bar-tag' }),
             relations: [
               { type: 'ownedBy', targetRef: 'Group:alsomine' },
               { type: 'ownedBy', targetRef: 'Group:shared' },

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetailsPage.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetailsPage.tsx
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, {useMemo} from 'react';
+import React, { useMemo } from 'react';
 import { useApi, useRouteRefParams } from '@backstage/core-plugin-api';
 import { scorecardRouteRef } from '../../../routes';
 import { cortexApiRef } from '../../../api';
 import { useAsync } from 'react-use';
 import { Progress, WarningPanel } from '@backstage/core-components';
 import { ScorecardDetails } from './ScorecardDetails';
-import {StringIndexable} from "../../ReportsPage/HeatmapPage/HeatmapUtils";
-import {HomepageEntity} from "../../../api/userInsightTypes";
-import {isNil, keyBy} from "lodash";
+import { StringIndexable } from '../../ReportsPage/HeatmapPage/HeatmapUtils';
+import { HomepageEntity } from '../../../api/userInsightTypes';
+import { isNil, keyBy } from 'lodash';
 
 export const ScorecardDetailsPage = () => {
   const { id: scorecardId } = useRouteRefParams(scorecardRouteRef);
@@ -48,8 +48,11 @@ export const ScorecardDetailsPage = () => {
   };
 
   const entitiesByTag: StringIndexable<HomepageEntity> = useMemo(
-    () => !isNil(entities) && !isNil(entities.entities) ? keyBy(Object.values(entities.entities), (entity) => entity.codeTag) : {},
-    [entities]
+    () =>
+      !isNil(entities) && !isNil(entities.entities)
+        ? keyBy(Object.values(entities.entities), entity => entity.codeTag)
+        : {},
+    [entities],
   );
 
   if (loading) {
@@ -68,6 +71,11 @@ export const ScorecardDetailsPage = () => {
   const ladder = ladders?.[0];
 
   return (
-    <ScorecardDetails entitiesByTag={entitiesByTag} ladder={ladder} scorecard={scorecard} scores={scores} />
+    <ScorecardDetails
+      entitiesByTag={entitiesByTag}
+      ladder={ladder}
+      scorecard={scorecard}
+      scores={scores}
+    />
   );
 };

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableCard.tsx
@@ -88,10 +88,9 @@ export const ScorecardsTableCard = ({
     return scores
       .map(score => {
         const currentLevel = score.ladderLevels?.[0]?.currentLevel;
-        const serviceName = entitiesByTag[score.componentRef]?.name ?? humanizeAnyEntityRef(
-          score.componentRef,
-          defaultComponentRefContext,
-        );
+        const serviceName =
+          entitiesByTag[score.componentRef]?.name ??
+          humanizeAnyEntityRef(score.componentRef, defaultComponentRefContext);
         return {
           level: currentLevel ? (
             <ScorecardLadderLevelBadge

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableCard.tsx
@@ -88,7 +88,7 @@ export const ScorecardsTableCard = ({
     return scores
       .map(score => {
         const currentLevel = score.ladderLevels?.[0]?.currentLevel;
-        const serviceName = humanizeAnyEntityRef(
+        const serviceName = entitiesByTag[score.componentRef]?.name ?? humanizeAnyEntityRef(
           score.componentRef,
           defaultComponentRefContext,
         );
@@ -104,7 +104,7 @@ export const ScorecardsTableCard = ({
               scorecardId={scorecardId}
               componentRef={score.componentRef}
             >
-              {entitiesByTag[score.componentRef]?.name ?? serviceName}
+              {serviceName}
             </ScorecardServiceRefLink>
           ),
           scorePercentage: score.scorePercentage,

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableCard.tsx
@@ -112,7 +112,7 @@ export const ScorecardsTableCard = ({
         };
       })
       .sort((left, right) => right.scorePercentage - left.scorePercentage);
-  }, [scorecardId, scores]);
+  }, [entitiesByTag, scorecardId, scores]);
 
   const showPagination = scores.length > PAGE_SIZE;
 

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableCard.tsx
@@ -27,8 +27,8 @@ import { humanizeAnyEntityRef } from '../../../../utils/types';
 import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
 import { ScorecardLadderLevelBadge } from '../../../Common/ScorecardLadderLevelBadge';
 import { ScorecardServiceRefLink } from '../../../ScorecardServiceRefLink';
-import {StringIndexable} from "../../../ReportsPage/HeatmapPage/HeatmapUtils";
-import {HomepageEntity} from "../../../../api/userInsightTypes";
+import { StringIndexable } from '../../../ReportsPage/HeatmapPage/HeatmapUtils';
+import { HomepageEntity } from '../../../../api/userInsightTypes';
 
 interface ScorecardsTableProps {
   entitiesByTag: StringIndexable<HomepageEntity>;

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsTableCard/ScorecardsTableCard.tsx
@@ -27,8 +27,11 @@ import { humanizeAnyEntityRef } from '../../../../utils/types';
 import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
 import { ScorecardLadderLevelBadge } from '../../../Common/ScorecardLadderLevelBadge';
 import { ScorecardServiceRefLink } from '../../../ScorecardServiceRefLink';
+import {StringIndexable} from "../../../ReportsPage/HeatmapPage/HeatmapUtils";
+import {HomepageEntity} from "../../../../api/userInsightTypes";
 
 interface ScorecardsTableProps {
+  entitiesByTag: StringIndexable<HomepageEntity>;
   scorecardId: number;
   scores: ScorecardServiceScore[];
 }
@@ -75,6 +78,7 @@ const columns: TableColumn[] = [
 ];
 
 export const ScorecardsTableCard = ({
+  entitiesByTag,
   scorecardId,
   scores,
 }: ScorecardsTableProps) => {
@@ -100,7 +104,7 @@ export const ScorecardsTableCard = ({
               scorecardId={scorecardId}
               componentRef={score.componentRef}
             >
-              {serviceName}
+              {entitiesByTag[score.componentRef]?.name ?? serviceName}
             </ScorecardServiceRefLink>
           ),
           scorePercentage: score.scorePercentage,

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
@@ -35,7 +35,7 @@ import { entityEquals } from '../../../utils/types';
 import { ScorecardsServiceNextRules } from './ScorecardsServiceNextRules';
 import { RuleOutcome } from '../../../api/types';
 import { cortexScorecardServicePageUrl } from '../../../utils/URLUtils';
-import { useCortexFrontendUrl } from '../../../utils/hooks';
+import {useCortexFrontendUrl, useEntitiesByTag} from '../../../utils/hooks';
 
 const useStyles = makeStyles({
   progress: {
@@ -49,6 +49,8 @@ export const ScorecardsServicePage = () => {
   const { scorecardId, kind, namespace, name } = useRouteRefParams(
     scorecardServiceDetailsRouteRef,
   );
+
+  const { entitiesByTag, loading: loadingEntities } = useEntitiesByTag();
 
   const entityRef = { kind, namespace, name };
 
@@ -75,7 +77,7 @@ export const ScorecardsServicePage = () => {
     setSelectedRules(score?.rules ?? []);
   }, [score]);
 
-  if (loading) {
+  if (loading || loadingEntities) {
     return <Progress />;
   }
 
@@ -108,7 +110,7 @@ export const ScorecardsServicePage = () => {
         </Box>
         <Box alignSelf="center" flex="1">
           <Typography variant="h4" component="h2">
-            <DefaultEntityRefLink entityRef={entityRef} />
+            <DefaultEntityRefLink entityRef={entityRef} title={entitiesByTag[entityRef.name]?.name} />
           </Typography>
         </Box>
         <Box alignSelf="center">

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
@@ -35,7 +35,7 @@ import { entityEquals } from '../../../utils/types';
 import { ScorecardsServiceNextRules } from './ScorecardsServiceNextRules';
 import { RuleOutcome } from '../../../api/types';
 import { cortexScorecardServicePageUrl } from '../../../utils/URLUtils';
-import {useCortexFrontendUrl, useEntitiesByTag} from '../../../utils/hooks';
+import { useCortexFrontendUrl, useEntitiesByTag } from '../../../utils/hooks';
 
 const useStyles = makeStyles({
   progress: {
@@ -110,7 +110,10 @@ export const ScorecardsServicePage = () => {
         </Box>
         <Box alignSelf="center" flex="1">
           <Typography variant="h4" component="h2">
-            <DefaultEntityRefLink entityRef={entityRef} title={entitiesByTag[entityRef.name]?.name} />
+            <DefaultEntityRefLink
+              entityRef={entityRef}
+              title={entitiesByTag[entityRef.name]?.name}
+            />
           </Typography>
         </Box>
         <Box alignSelf="center">

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -43,6 +43,9 @@ import { CortexApi } from '../api/CortexApi';
 import { EntityFilterGroup } from '../filters';
 import { FilterDefinition } from '../components/FilterCard/Filters';
 import { extensionApiRef } from '../api/ExtensionApi';
+import { StringIndexable } from '../components/ReportsPage/HeatmapPage/HeatmapUtils';
+import { HomepageEntity } from '../api/userInsightTypes';
+import { isNil, keyBy } from 'lodash';
 
 export function useInput(
   initialValue: string | undefined = undefined,
@@ -323,4 +326,24 @@ export function useCortexFrontendUrl(): string {
     config.getOptionalString('cortex.frontendBaseUrl') ??
     'https://app.getcortexapp.com'
   );
+}
+
+export function useEntitiesByTag(): {
+  entitiesByTag: StringIndexable<HomepageEntity>;
+  loading: boolean;
+} {
+  const { value: entities, loading } = useCortexApi(
+    api => api.getCatalogEntities(),
+    [],
+  );
+
+  const entitiesByTag: StringIndexable<HomepageEntity> = useMemo(
+    () =>
+      !isNil(entities) && !isNil(entities.entities)
+        ? keyBy(Object.values(entities.entities), entity => entity.codeTag)
+        : {},
+    [entities],
+  );
+
+  return { entitiesByTag, loading };
 }


### PR DESCRIPTION
## Change description

> Backstage reports use tag for displaying a service row. Instead use the corresponding name of the service to display the row.
Note: we must keep the tag as the metadata.name so the entity can still be identified

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

> [CET-3001](https://cortex1.atlassian.net/browse/CET-3001)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[CET-3001]: https://cortex1.atlassian.net/browse/CET-3001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ