### PR TITLE
[CET-2856] Add rule filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -42,6 +42,13 @@ export interface Rule extends RuleName {
   failureMessage?: string;
   dateCreated?: string;
   weight: number;
+  filter?: RuleFilter;
+}
+
+export interface RuleFilter {
+  query?: string;
+  includedTags?: string[];
+  excludedTags?: string[];
 }
 
 export function ruleName(rule: RuleName): string {
@@ -59,6 +66,7 @@ export interface ScorecardLevelRule {
   expression: string;
   title?: string;
   description?: string;
+  filter?: RuleFilter;
 }
 
 export interface ScorecardLevel {
@@ -247,6 +255,7 @@ export interface InitiativeRule {
   expression: string;
   title: string;
   description?: string;
+  filter?: RuleFilter;
 }
 
 export interface InitiativeLevel {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -178,8 +178,8 @@ export interface ApplicableRuleOutcome extends RuleOutcomeBase {
 
 export interface NotApplicableRuleOutcome extends RuleOutcomeBase {
   endDate?: string;
-  requestedDate: string;
-  approvedDate: string;
+  requestedDate?: string;
+  approvedDate?: string;
   type: RuleOutcomeType.NOT_APPLICABLE;
 }
 

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardRulesCard/ScorecardRuleRow.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardRulesCard/ScorecardRuleRow.tsx
@@ -41,20 +41,20 @@ export const ScorecardRuleRow = ({ rule }: ScorecardRuleRowProps) => {
   const classes = useDetailCardStyles();
 
   const [open, setOpen] = useState(false);
-  const showExpandButton = rule.description || rule.title;
+  const showExpandButton = rule.description || rule.title || rule.filter;
   const hasTitle = !!rule.title;
   const hasWeight = 'weight' in rule;
 
   return (
     <React.Fragment>
-      {showExpandButton && (
-        <Grid item xs={1}>
+      <Grid item lg={1}>
+        {showExpandButton && (
           <IconButton size="small" onClick={() => setOpen(!open)}>
             {open ? <KeyboardArrowDownIcon /> : <KeyboardArrowRight />}
           </IconButton>
-        </Grid>
-      )}
-      <Grid item xs={4}>
+        )}
+      </Grid>
+      <Grid item lg={9}>
         <Typography variant="subtitle1" className={classes.rule}>
           {ruleName(rule)}
         </Typography>
@@ -70,40 +70,40 @@ export const ScorecardRuleRow = ({ rule }: ScorecardRuleRowProps) => {
                 {rule.expression}
               </MetadataItem>
             )}
+            {rule.filter?.query && (
+              <MetadataItem gridSizes={{ xs: 12 }} label="Filter">
+                {rule.filter.query}
+              </MetadataItem>
+            )}
+            {rule.filter?.includedTags &&
+              rule.filter?.includedTags.length !== 0 && (
+                <MetadataItem gridSizes={{ xs: 12 }} label="Applies to">
+                  {rule.filter?.includedTags.map(s => (
+                    <Chip
+                      key={`Scorecard-Filter-IncludedServiceGroup-${s}`}
+                      size="small"
+                      label={s}
+                    />
+                  ))}
+                </MetadataItem>
+              )}
+            {rule.filter?.excludedTags &&
+              rule.filter?.excludedTags.length !== 0 && (
+                <MetadataItem gridSizes={{ xs: 12 }} label="Does not apply to">
+                  {rule.filter.excludedTags.map(s => (
+                    <Chip
+                      key={`Scorecard-Filter-ExcludedServiceGroup-${s}`}
+                      size="small"
+                      label={s}
+                    />
+                  ))}
+                </MetadataItem>
+              )}
           </>
         </Collapse>
       </Grid>
-      <Grid item xs={4}>
-        {hasWeight && (
-          <Typography className={classes.rule}>{rule.weight}</Typography>
-        )}
-      </Grid>
-      <Grid item xs={4}>
-        {rule.filter?.query && (
-          <Typography className={classes.rule}>{rule.filter.query}</Typography>
-        )}
-        {rule.filter?.includedTags && rule.filter?.includedTags.length !== 0 && (
-          <MetadataItem gridSizes={{ xs: 12 }} label="Applies to">
-            {rule.filter?.includedTags.map(s => (
-              <Chip
-                key={`Scorecard-Filter-IncludedServiceGroup-${s}`}
-                size="small"
-                label={s}
-              />
-            ))}
-          </MetadataItem>
-        )}
-        {rule.filter?.excludedTags && rule.filter?.excludedTags.length !== 0 && (
-          <MetadataItem gridSizes={{ xs: 12 }} label="Does not apply to">
-            {rule.filter.excludedTags.map(s => (
-              <Chip
-                key={`Scorecard-Filter-ExcludedServiceGroup-${s}`}
-                size="small"
-                label={s}
-              />
-            ))}
-          </MetadataItem>
-        )}
+      <Grid item lg={2}>
+        {hasWeight && <b>{rule.weight}</b>}
       </Grid>
     </React.Fragment>
   );

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardRulesCard/ScorecardRuleRow.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardRulesCard/ScorecardRuleRow.tsx
@@ -21,7 +21,13 @@ import {
 } from '../../../../api/types';
 import { useDetailCardStyles } from '../../../../styles/styles';
 import React, { useState } from 'react';
-import { Collapse, Grid, IconButton, Typography } from '@material-ui/core';
+import {
+  Chip,
+  Collapse,
+  Grid,
+  IconButton,
+  Typography,
+} from '@material-ui/core';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 import { MetadataItem } from '../../../MetadataItem';
@@ -41,14 +47,14 @@ export const ScorecardRuleRow = ({ rule }: ScorecardRuleRowProps) => {
 
   return (
     <React.Fragment>
-      <Grid item lg={1}>
-        {showExpandButton && (
+      {showExpandButton && (
+        <Grid item xs={1}>
           <IconButton size="small" onClick={() => setOpen(!open)}>
             {open ? <KeyboardArrowDownIcon /> : <KeyboardArrowRight />}
           </IconButton>
-        )}
-      </Grid>
-      <Grid item lg={9}>
+        </Grid>
+      )}
+      <Grid item xs={4}>
         <Typography variant="subtitle1" className={classes.rule}>
           {ruleName(rule)}
         </Typography>
@@ -67,8 +73,37 @@ export const ScorecardRuleRow = ({ rule }: ScorecardRuleRowProps) => {
           </>
         </Collapse>
       </Grid>
-      <Grid item lg={2}>
-        {hasWeight && <b>{rule.weight}</b>}
+      <Grid item xs={4}>
+        {hasWeight && (
+          <Typography className={classes.rule}>{rule.weight}</Typography>
+        )}
+      </Grid>
+      <Grid item xs={4}>
+        {rule.filter?.query && (
+          <Typography className={classes.rule}>{rule.filter.query}</Typography>
+        )}
+        {rule.filter?.includedTags && rule.filter?.includedTags.length !== 0 && (
+          <MetadataItem gridSizes={{ xs: 12 }} label="Applies to">
+            {rule.filter?.includedTags.map(s => (
+              <Chip
+                key={`Scorecard-Filter-IncludedServiceGroup-${s}`}
+                size="small"
+                label={s}
+              />
+            ))}
+          </MetadataItem>
+        )}
+        {rule.filter?.excludedTags && rule.filter?.excludedTags.length !== 0 && (
+          <MetadataItem gridSizes={{ xs: 12 }} label="Does not apply to">
+            {rule.filter.excludedTags.map(s => (
+              <Chip
+                key={`Scorecard-Filter-ExcludedServiceGroup-${s}`}
+                size="small"
+                label={s}
+              />
+            ))}
+          </MetadataItem>
+        )}
       </Grid>
     </React.Fragment>
   );

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardRulesCard/ScorecardRulesCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardRulesCard/ScorecardRulesCard.tsx
@@ -32,16 +32,7 @@ export const ScorecardRulesCard = ({ scorecard }: ScorecardRulesCardProps) => {
 
   return (
     <InfoCard title="Rules" className={classes.root}>
-      <Grid container spacing={2}>
-        <Grid item xs={4}>
-          <b>Rule</b>
-        </Grid>
-        <Grid item xs={4}>
-          <b>Weight</b>
-        </Grid>
-        <Grid item xs={4}>
-          <b>Filter</b>
-        </Grid>
+      <Grid container>
         {sortedRules.map(rule => (
           <ScorecardRuleRow key={`ScorecardRuleRow-${rule.id}`} rule={rule} />
         ))}

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardRulesCard/ScorecardRulesCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardRulesCard/ScorecardRulesCard.tsx
@@ -32,7 +32,16 @@ export const ScorecardRulesCard = ({ scorecard }: ScorecardRulesCardProps) => {
 
   return (
     <InfoCard title="Rules" className={classes.root}>
-      <Grid container>
+      <Grid container spacing={2}>
+        <Grid item xs={4}>
+          <b>Rule</b>
+        </Grid>
+        <Grid item xs={4}>
+          <b>Weight</b>
+        </Grid>
+        <Grid item xs={4}>
+          <b>Filter</b>
+        </Grid>
         {sortedRules.map(rule => (
           <ScorecardRuleRow key={`ScorecardRuleRow-${rule.id}`} rule={rule} />
         ))}


### PR DESCRIPTION
## Change description

> Description here

This PR exposes rule filters on the Scorecard details page alongside the rule. Rule filters for CQL and group inclusion/exclusion are accounted for.

<img width="513" alt="Screen Shot 2023-05-18 at 11 08 26 AM" src="https://github.com/cortexapps/backstage-plugin/assets/8609773/6759797e-5bc8-42bc-bee8-20ef5ca66412">
<img width="481" alt="Screen Shot 2023-05-18 at 11 06 07 AM" src="https://github.com/cortexapps/backstage-plugin/assets/8609773/b9d75c87-bb10-4235-9038-3b4ea4537d2e">

See Scorecard detail page rule will be shown as the following if it is filtered out:

<img width="511" alt="Screen Shot 2023-05-17 at 3 23 31 PM" src="https://github.com/cortexapps/backstage-plugin/assets/8609773/8282af38-6c7c-4530-81d2-d319f7b15a43">



## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
