### PR TITLE
fix: handle trailing slash in path for Scorecard widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/CortexScorecardWidget/CortexScorecardWidget.tsx
+++ b/src/components/CortexScorecardWidget/CortexScorecardWidget.tsx
@@ -135,9 +135,10 @@ export const CortexScorecardWidget = ({
     <EntityScorecardsCard
       title={'Cortex Scorecards'}
       scores={scoresToDisplay}
-      onSelect={scorecardId =>
-        navigate(`${location.pathname}/cortex?scorecardId=${scorecardId}`)
-      }
+      onSelect={scorecardId => {
+        const target = location.pathname.endsWith('/') ? 'cortex' : '/cortex';
+        navigate(`${location.pathname}${target}?scorecardId=${scorecardId}`);
+      }}
     />
   );
 };


### PR DESCRIPTION
## Change description

At least one customer is navigating to an invalid URL due to a double slash (e.g. `/component/abcd/` => `/component/abcd//cortex?scorecard=123`). This PR adds a check for extra paranoia to not add a double slash.

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
