### PR TITLE
[CET-4523] Break up Backstage sync into separate chunked requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -91,17 +91,27 @@ export class CortexClient implements CortexApi {
       ? entities.map(entity => applyCustomMappings(entity, customMappings))
       : entities;
 
-    if (gzipContents) {
-      return await this.postWithGzipBody(`/api/backstage/v1/entities/sync`, {
-        entities: withCustomMappings,
-        teamOverrides,
-      });
-    } else {
-      return await this.post(`/api/backstage/v1/entities/sync`, {
-        entities: withCustomMappings,
-        teamOverrides,
-      });
+    const post = async (path: string, body?: any) => {
+        return gzipContents ? await this.postVoidWithGzipBody(path, body) : await this.postVoid(path, body)
     }
+
+    await this.postVoid('/api/backstage/v2/entities/sync-init')
+    let maxListSize = Math.max(
+      withCustomMappings.length,
+      teamOverrides?.teams?.length ?? 0,
+      teamOverrides?.relationships?.length ?? 0
+    )
+    for (let i = 0; i < maxListSize; i+= CHUNK_SIZE) {
+      await post(`/api/backstage/v2/entities/sync-chunked`, {
+        entities: withCustomMappings.slice(i, i + CHUNK_SIZE),
+        teamOverrides: teamOverrides ? {
+          teams: teamOverrides.teams.slice(i, i + CHUNK_SIZE),
+          relationships: teamOverrides.relationships.slice(i, i + CHUNK_SIZE)
+        } : undefined,
+      })
+    }
+
+    return await this.post('/api/backstage/v2/entities/sync-submit')
   }
 
   async getServiceScores(
@@ -256,15 +266,15 @@ export class CortexClient implements CortexApi {
   }
 
   async getEntitySyncProgress(): Promise<EntitySyncProgress> {
-    return await this.get(`/api/backstage/v1/entities/progress`);
+    return await this.get(`/api/backstage/v2/entities/progress`);
   }
 
   async getLastEntitySyncTime(): Promise<LastEntitySyncTime> {
-    return await this.get(`/api/backstage/v1/entities/last-sync`);
+    return await this.get(`/api/backstage/v2/entities/last-sync`);
   }
 
   async cancelEntitySync(): Promise<void> {
-    await this.delete(`/api/backstage/v1/entities/sync`);
+    await this.delete(`/api/backstage/v2/entities/sync`);
   }
 
   async getUserOncallByEmail(): Promise<OncallsResponse> {
@@ -349,7 +359,24 @@ export class CortexClient implements CortexApi {
     return response.json();
   }
 
-  private async postWithGzipBody(path: string, body?: any): Promise<any> {
+  private async postVoid(path: string, body?: any): Promise<void> {
+    const basePath = await this.getBasePath();
+    const url = `${basePath}${path}`;
+
+    const response = await this.fetchAuthenticated(url, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (response.status !== 200) {
+      throw new Error(`Error communicating with Cortex`);
+    }
+
+    return;
+  }
+
+  private async postVoidWithGzipBody(path: string, body?: any): Promise<void> {
     const basePath = await this.getBasePath();
     const url = `${basePath}${path}`;
 
@@ -369,7 +396,7 @@ export class CortexClient implements CortexApi {
       throw new Error(`Error communicating with Cortex`);
     }
 
-    return response.json();
+    return;
   }
 
   private async delete(path: string, body?: any): Promise<void> {
@@ -421,3 +448,5 @@ export class CortexClient implements CortexApi {
     }
   }
 }
+
+const CHUNK_SIZE = 1;

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -449,4 +449,4 @@ export class CortexClient implements CortexApi {
   }
 }
 
-const CHUNK_SIZE = 1;
+const CHUNK_SIZE = 1000;

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -118,8 +118,8 @@ export class CortexClient implements CortexApi {
       await post(`/api/backstage/v2/entities/sync-chunked`, {
         entities: [],
         teamOverrides: {
-          teams: teamOverridesRelationshipsChunk,
-          relationships: []
+          teams: [],
+          relationships: teamOverridesRelationshipsChunk,
         }
       })
     }

--- a/src/components/Common/PollingLinearGauge.tsx
+++ b/src/components/Common/PollingLinearGauge.tsx
@@ -36,8 +36,6 @@ const PollingLinearGauge: React.FC<PollingLinearGaugeProps> = ({
   poll,
   value,
 }) => {
-  const isDone = value === 1 || done;
-
   const [exponentialBackoff, setExponentialBackoff] = useState(
     () =>
       new ExponentialBackoff({
@@ -52,7 +50,7 @@ const PollingLinearGauge: React.FC<PollingLinearGaugeProps> = ({
       await poll();
       setExponentialBackoff(backoff => backoff.advance());
     },
-    isDone ? null : exponentialBackoff.delay(),
+    done ? null : exponentialBackoff.delay(),
   );
 
   return <LinearGauge value={value} />;

--- a/src/components/SettingsPage/SyncCard.tsx
+++ b/src/components/SettingsPage/SyncCard.tsx
@@ -83,8 +83,10 @@ export const SyncCard = () => {
   >(null);
 
   const [lastSyncedTime, setLastSyncedTime] = useState<string | null>(null);
+  const [isSubmittingTask, setIsSubmittingTask] = useState(false);
 
   const submitEntitySync = useCallback(async () => {
+    setIsSubmittingTask(true);
     const { items: entities } = await catalogApi.getEntities();
     const shouldGzipBody =
       config.getOptionalBoolean('cortex.syncWithGzip') ?? false;
@@ -97,6 +99,7 @@ export const SyncCard = () => {
       groupOverrides,
     );
     setSyncTaskProgressPercentage(progress.percentage);
+    setIsSubmittingTask(false);
   }, [catalogApi, config, cortexApi, extensionApi]);
 
   const cancelEntitySync = useCallback(async () => {
@@ -131,7 +134,7 @@ export const SyncCard = () => {
       title="Sync entities"
       action={
         <SyncButton
-          isSyncing={syncTaskProgressPercentage !== null}
+          isSyncing={syncTaskProgressPercentage !== null || isSubmittingTask}
           submitSyncTask={submitEntitySync}
         />
       }


### PR DESCRIPTION
## Background
We're getting timeouts from our current job as of a month ago. So this PR will start sending chunked requests over instead, to improve fault tolerance of the sync job.

## This PR
* Start chunking sync request into separate `POST`s 
* Fix bug where backend tasks at 100% but `IN_PROGRESS` keep `PollingProgressBar` in DOM
* Show loader when sending over Backstage entities, instead of frozen UI until the progress bar mounts

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
