### PR TITLE
[CET-4196] Optional filter to limit entities sent to Cortex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -74,7 +74,7 @@
     "@backstage/cli": "^0.22.5",
     "@backstage/dev-utils": "^1.0.13",
     "@backstage/test-utils": "^1.2.6",
-    "@cortexapps/backstage-plugin-extensions": "0.0.18",
+    "@cortexapps/backstage-plugin-extensions": "file:.yalc/@cortexapps/backstage-plugin-extensions",
     "@cortexapps/eslint-config-oss": "^0.0.3",
     "@spotify/prettier-config": "^11.0.0",
     "@types/enzyme": "^3.10.12",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@backstage/cli": "^0.22.5",
     "@backstage/dev-utils": "^1.0.13",
     "@backstage/test-utils": "^1.2.6",
-    "@cortexapps/backstage-plugin-extensions": "file:.yalc/@cortexapps/backstage-plugin-extensions",
+    "@cortexapps/backstage-plugin-extensions": "0.0.19",
     "@cortexapps/eslint-config-oss": "^0.0.3",
     "@spotify/prettier-config": "^11.0.0",
     "@types/enzyme": "^3.10.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/api/CortexApi.ts
+++ b/src/api/CortexApi.ts
@@ -34,10 +34,7 @@ import {
 import { Entity } from '@backstage/catalog-model';
 import { Moment } from 'moment/moment';
 import { AnyEntityRef } from '../utils/types';
-import {
-  CustomMapping,
-  TeamOverrides,
-} from '@cortexapps/backstage-plugin-extensions';
+import { TeamOverrides } from '@cortexapps/backstage-plugin-extensions';
 import {
   GetUserInsightsResponse,
   HomepageEntityResponse,
@@ -91,7 +88,6 @@ export interface CortexApi {
   submitEntitySync(
     entities: Entity[],
     shouldGzipBody: boolean,
-    customMappings?: CustomMapping[],
     teamOverrides?: TeamOverrides,
   ): Promise<EntitySyncProgress>;
 

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -37,11 +37,7 @@ import { Entity } from '@backstage/catalog-model';
 import { Buffer } from 'buffer';
 import { Moment } from 'moment/moment';
 import { AnyEntityRef, stringifyAnyEntityRef } from '../utils/types';
-import {
-  CustomMapping,
-  TeamOverrides,
-} from '@cortexapps/backstage-plugin-extensions';
-import { applyCustomMappings } from '../utils/ComponentUtils';
+import { TeamOverrides } from '@cortexapps/backstage-plugin-extensions';
 import {
   createApiRef,
   DiscoveryApi,
@@ -52,7 +48,7 @@ import {
   GetUserInsightsResponse,
   HomepageEntityResponse,
 } from './userInsightTypes';
-import { chunk } from "lodash";
+import { chunk } from 'lodash';
 
 export const cortexApiRef = createApiRef<CortexApi>({
   id: 'plugin.cortex.service',
@@ -85,46 +81,49 @@ export class CortexClient implements CortexApi {
   async submitEntitySync(
     entities: Entity[],
     gzipContents: boolean,
-    customMappings?: CustomMapping[],
     teamOverrides?: TeamOverrides,
   ): Promise<EntitySyncProgress> {
-    const withCustomMappings: Entity[] = customMappings
-      ? entities.map(entity => applyCustomMappings(entity, customMappings))
-      : entities;
-
     const post = async (path: string, body?: any) => {
-        return gzipContents ? await this.postVoidWithGzipBody(path, body) : await this.postVoid(path, body)
-    }
+      return gzipContents
+        ? await this.postVoidWithGzipBody(path, body)
+        : await this.postVoid(path, body);
+    };
 
-    await this.postVoid('/api/backstage/v2/entities/sync-init')
+    await this.postVoid('/api/backstage/v2/entities/sync-init');
 
-    for (let customMappingsChunk of chunk(withCustomMappings, CHUNK_SIZE)) {
+    for (let customMappingsChunk of chunk(entities, CHUNK_SIZE)) {
       await post(`/api/backstage/v2/entities/sync-chunked`, {
         entities: customMappingsChunk,
-      })
+      });
     }
 
-    for (let teamOverridesTeamChunk of chunk(teamOverrides?.teams ?? [], CHUNK_SIZE)) {
+    for (let teamOverridesTeamChunk of chunk(
+      teamOverrides?.teams ?? [],
+      CHUNK_SIZE,
+    )) {
       await post(`/api/backstage/v2/entities/sync-chunked`, {
         entities: [],
         teamOverrides: {
           teams: teamOverridesTeamChunk,
-          relationships: []
-        }
-      })
+          relationships: [],
+        },
+      });
     }
 
-    for (let teamOverridesRelationshipsChunk of chunk(teamOverrides?.relationships ?? [], CHUNK_SIZE)) {
+    for (let teamOverridesRelationshipsChunk of chunk(
+      teamOverrides?.relationships ?? [],
+      CHUNK_SIZE,
+    )) {
       await post(`/api/backstage/v2/entities/sync-chunked`, {
         entities: [],
         teamOverrides: {
           teams: [],
           relationships: teamOverridesRelationshipsChunk,
-        }
-      })
+        },
+      });
     }
 
-    return await this.post('/api/backstage/v2/entities/sync-submit')
+    return await this.post('/api/backstage/v2/entities/sync-submit');
   }
 
   async getServiceScores(
@@ -446,7 +445,9 @@ export class CortexClient implements CortexApi {
 
     const headers = {
       ...init?.headers,
-      Authorization: `Bearer ${(token ?? '').replace(/^[Bb]earer\s+/, '').trim()}`,
+      Authorization: `Bearer ${(token ?? '')
+        .replace(/^[Bb]earer\s+/, '')
+        .trim()}`,
       'x-cortex-email': email ?? '',
       'x-cortex-name': displayName ?? '',
     };

--- a/src/components/CortexGroupActionItemsWidget/CortexGroupActionItemsWidget.test.tsx
+++ b/src/components/CortexGroupActionItemsWidget/CortexGroupActionItemsWidget.test.tsx
@@ -149,7 +149,7 @@ describe('<CortexGroupActionItemsWidget/>', () => {
       );
     });
     // The animation takes some time so wait for the elements to be removed
-    await waitForElementToBeRemoved(queryByText(/Basic service catalog/));
+    await waitForElementToBeRemoved(() => queryByText(/Basic service catalog/));
     expect(queryByText(/01\/01\/2000/)).not.toBeInTheDocument();
     expect(queryByText(/Git initiative/)).not.toBeInTheDocument();
     expect(queryByText(/05\/05\/2000/)).not.toBeInTheDocument();

--- a/src/components/SettingsPage/SyncCard.tsx
+++ b/src/components/SettingsPage/SyncCard.tsx
@@ -29,6 +29,8 @@ import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { extensionApiRef } from '../../api/ExtensionApi';
 import PollingLinearGauge from '../Common/PollingLinearGauge';
 import moment from 'moment';
+import { Entity } from '@backstage/catalog-model';
+import { applyCustomMappings } from '../../utils/ComponentUtils';
 
 interface SyncButtonProps {
   isSyncing: boolean;
@@ -85,17 +87,37 @@ export const SyncCard = () => {
   const [lastSyncedTime, setLastSyncedTime] = useState<string | null>(null);
   const [isSubmittingTask, setIsSubmittingTask] = useState(false);
 
+  const getBackstageEntities = useCallback(async () => {
+    const syncEntityFilter = await extensionApi.getSyncEntityFilter?.();
+    const { items: entities } = await catalogApi.getEntities(
+      syncEntityFilter?.kinds
+        ? { filter: { kind: syncEntityFilter?.kinds } }
+        : undefined,
+    );
+
+    const filteredEntities = syncEntityFilter?.entityFilter
+      ? entities.filter(syncEntityFilter?.entityFilter)
+      : entities;
+
+    const customMappings = await extensionApi.getCustomMappings?.();
+    const withCustomMappings: Entity[] = customMappings
+      ? filteredEntities.map(entity =>
+          applyCustomMappings(entity, customMappings),
+        )
+      : filteredEntities;
+
+    return withCustomMappings;
+  }, [catalogApi, extensionApi]);
+
   const submitEntitySync = useCallback(async () => {
     setIsSubmittingTask(true);
-    const { items: entities } = await catalogApi.getEntities();
+    const entities = await getBackstageEntities();
     const shouldGzipBody =
       config.getOptionalBoolean('cortex.syncWithGzip') ?? false;
-    const customMappings = await extensionApi.getCustomMappings?.();
     const groupOverrides = await extensionApi.getTeamOverrides?.(entities);
     const progress = await cortexApi.submitEntitySync(
       entities,
       shouldGzipBody,
-      customMappings,
       groupOverrides,
     );
     setSyncTaskProgressPercentage(progress.percentage);

--- a/src/components/SettingsPage/SyncCard.tsx
+++ b/src/components/SettingsPage/SyncCard.tsx
@@ -122,7 +122,7 @@ export const SyncCard = () => {
     );
     setSyncTaskProgressPercentage(progress.percentage);
     setIsSubmittingTask(false);
-  }, [catalogApi, config, cortexApi, extensionApi]);
+  }, [getBackstageEntities, config, cortexApi, extensionApi]);
 
   const cancelEntitySync = useCallback(async () => {
     await cortexApi.cancelEntitySync();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,10 +1503,8 @@
   resolved "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz#fb8f7ca2324fd54954824e864f9a61a82cb78fe0"
   integrity sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==
 
-"@cortexapps/backstage-plugin-extensions@0.0.18":
-  version "0.0.18"
-  resolved "https://registry.npmjs.org/@cortexapps/backstage-plugin-extensions/-/backstage-plugin-extensions-0.0.18.tgz#e55d85324ca52f0f9b5afa7cfbeba23e5136e516"
-  integrity sha512-3fBCwe5CUpuDPcumtqbLW+12uM0CLGo9P+KLYsv4EIrYFH0RWlsgkJjAq4a75p5e2tIkKVUfOf23fbAyEQEu2w==
+"@cortexapps/backstage-plugin-extensions@file:.yalc/@cortexapps/backstage-plugin-extensions":
+  version "0.0.19"
   dependencies:
     "@backstage/catalog-model" "^1.2.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,8 +1503,10 @@
   resolved "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz#fb8f7ca2324fd54954824e864f9a61a82cb78fe0"
   integrity sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==
 
-"@cortexapps/backstage-plugin-extensions@file:.yalc/@cortexapps/backstage-plugin-extensions":
+"@cortexapps/backstage-plugin-extensions@0.0.19":
   version "0.0.19"
+  resolved "https://registry.npmjs.org/@cortexapps/backstage-plugin-extensions/-/backstage-plugin-extensions-0.0.19.tgz#ef0f5a4e99fe12b3c432ecd1e0b1a2158947e113"
+  integrity sha512-lZfK94+UxfWzUwhgGlgWn9anjk2GNrYVvYrkih8Axr4n/AuaNYejgRsQqNpayOt+KBX08D1KEQvOsWIExjvL/g==
   dependencies:
     "@backstage/catalog-model" "^1.2.1"
 


### PR DESCRIPTION
## Change description
Give users the option to limit which entities are sent over to Cortex for the YAML conversion / sync -- we're sending way too much data for larger instances of Backstage, and this will give some configuration power back to the users if there's completely unused data being sent to Cortex.

Some additional refactors / cleanups:
* Ran prettier on `CortexClient.ts`
* Moved "custom mappings" application logic out of `CortexClient`

Depends on: https://github.com/cortexapps/backstage-plugin-extensions/pull/17

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
