### PR TITLE
CET-6731   [Unity] User can't access the Backstage plugin interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.4.4
+
+- Support non ISO-8859-1 characters in request headers.
+
 ### 2.4.3
 
 - Show expiration banner when Cortex access is expiring & block access after expiration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2.4.4
 
-- Support non ISO-8859-1 characters in request headers.
+- Add support for non ISO-8859-1 characters in request headers to the Cortex API. This fixes authentication for users with these characters in their name.
 
 ### 2.4.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/api/CortexClient.test.ts
+++ b/src/api/CortexClient.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CortexClient } from './CortexClient';
+import { IdentityApi } from '@backstage/core-plugin-api';
+import { mock } from 'jest-mock-extended';
+
+const mockFetch = jest.fn().mockResolvedValue({
+  status: 200,
+  json: () => Promise.resolve({}),
+});
+global.fetch = mockFetch;
+
+describe('CortexClient', () => {
+  const getCortexClient = (
+    email: string = 'e@mail.com',
+    displayName: string = 'Na Me',
+  ) =>
+    new CortexClient({
+      discoveryApi: {
+        getBaseUrl: () => Promise.resolve('http://localhost:3000'),
+      },
+      identityApi: mock<IdentityApi>({
+        getCredentials: () =>
+          Promise.resolve({
+            token: 'toKen',
+          }),
+        getProfileInfo: () =>
+          Promise.resolve({
+            email,
+            displayName,
+          }),
+      }),
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  [
+    {
+      email: 'e@mail.com',
+      displayName: 'NaMe',
+    },
+    {
+      email: 'tony@cortex.io',
+      displayName: 'Tony Vespa',
+    },
+    {
+      email: 'foreign.exchange.student@cortex.io',
+      displayName: 'Fez Ąğłóżź',
+    },
+  ].forEach(({ email, displayName }) => {
+    it(`fetch is called with x-cortex headers [${email}] [${displayName}]`, async () => {
+      await getCortexClient(email, displayName).cancelEntitySync();
+      expect(fetch).toBeCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'x-cortex-email': encodeURIComponent(email),
+            'x-cortex-name': encodeURIComponent(displayName),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -37,6 +37,7 @@ import { CortexApi } from './CortexApi';
 import { Entity } from '@backstage/catalog-model';
 import { Buffer } from 'buffer';
 import { Moment } from 'moment/moment';
+import { chunk, mapValues } from 'lodash';
 import { AnyEntityRef, stringifyAnyEntityRef } from '../utils/types';
 import { TeamOverrides } from '@cortexapps/backstage-plugin-extensions';
 import {
@@ -49,7 +50,6 @@ import {
   GetUserInsightsResponse,
   HomepageEntityResponse,
 } from './userInsightTypes';
-import { chunk } from 'lodash';
 
 export const cortexApiRef = createApiRef<CortexApi>({
   id: 'plugin.cortex.service',
@@ -448,23 +448,22 @@ export class CortexClient implements CortexApi {
       displayName = profileInfo.displayName;
     }
 
-    const headers = {
-      ...init?.headers,
-      Authorization: `Bearer ${(token ?? '')
-        .replace(/^[Bb]earer\s+/, '')
-        .trim()}`,
-      'x-cortex-email': email ?? '',
-      'x-cortex-name': displayName ?? '',
-    };
+    const headers =
+      token !== undefined
+        ? {
+          ...init?.headers,
+          Authorization: `Bearer ${(token ?? '').replace(/^[Bb]earer\s+/, '').trim()}`,
+          'x-cortex-email': email ?? '',
+          'x-cortex-name': displayName ?? '',
+        }
+        : {
+          ...init?.headers,
+        };
 
-    if (token !== undefined) {
-      return fetch(input, {
-        ...init,
-        headers: headers,
-      });
-    } else {
-      return fetch(input, init);
-    }
+    return fetch(input, {
+      ...init,
+      headers: mapValues(headers, encodeURIComponent),
+    });
   }
 }
 

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -448,22 +448,27 @@ export class CortexClient implements CortexApi {
       displayName = profileInfo.displayName;
     }
 
-    const headers =
-      token !== undefined
-        ? {
-          ...init?.headers,
-          Authorization: `Bearer ${(token ?? '').replace(/^[Bb]earer\s+/, '').trim()}`,
-          'x-cortex-email': email ?? '',
-          'x-cortex-name': displayName ?? '',
-        }
-        : {
-          ...init?.headers,
-        };
+    const xCortexHeaders = mapValues({
+      'x-cortex-email': email ?? '',
+      'x-cortex-name': displayName ?? '',
+    }, encodeURIComponent);
 
-    return fetch(input, {
-      ...init,
-      headers: mapValues(headers, encodeURIComponent),
-    });
+    const headers = {
+      ...init?.headers,
+      Authorization: `Bearer ${(token ?? '')
+        .replace(/^[Bb]earer\s+/, '')
+        .trim()}`,
+      ...xCortexHeaders,
+    };
+
+    if (token !== undefined) {
+      return fetch(input, {
+        ...init,
+        headers: headers,
+      });
+    } else {
+      return fetch(input, init);
+    }
   }
 }
 


### PR DESCRIPTION
## Change description

**REQUIRES BE PR** https://github.com/cortexapps/brain-backend/pull/5072

We use own headers in backstage plugin
```
'x-cortex-email': email ?? '',
'x-cortex-name': displayName ?? '',
```
but with non  ISO-8859-1 characters like `ğ` in user names it caused: 
```
index-cc953267.esm.js:449 TypeError: Failed to execute 'fetch' on 'Window': Failed to read the 'headers' property from 'RequestInit': String contains non ISO-8859-1 code point.
    at CortexClient.fetchAuthenticated (index-cc953267.esm.js:444:1)
    at async CortexClient.get (index-cc953267.esm.js:353:1)
    at async eval (index-35f4277a.esm.js:2361:1)
```
Idea:
1. encode our headers on backstage-plugin
2. decode them on brain-brackend https://github.com/cortexapps/brain-backend/pull/5072

tested manually by adding headers like
```
          'x-cortex-name': 'aaağaaa'
```
and decoding them on BE.

This looks to be working when tested locally, but for me it is a bit manual approach. @FoodProduct @cristinabuenahora @igorRoog do you know of any global var that we can set to automagically encode all headers maybe?

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [x] The changelog has been updated as appropriate
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
