### PR TITLE
CET-6941 Fix StatsItem color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.5.1
+
+- Fix label color (light theme)
+
 ### 2.5.0
 
 - Overhaul the UI of Scorecard pages with better visualization of rules & levels

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/Common/StatsItem.tsx
+++ b/src/components/Common/StatsItem.tsx
@@ -17,7 +17,6 @@ import React, { useMemo } from 'react';
 import { percentify } from '../../utils/NumberUtils';
 import { ordinal } from '../../utils/strings';
 import { Box, Typography, alpha, withStyles } from '@material-ui/core';
-import { fallbackPalette } from '../../styles/styles';
 
 export type StatNumberType = 'NTH' | 'PERCENTAGE' | 'NONE';
 
@@ -28,11 +27,11 @@ export interface StatsItemProps {
   value: number;
 }
 
-export const CaptionTypography = withStyles({
+export const CaptionTypography = withStyles(theme => ({
   root: {
-    color: alpha(fallbackPalette.common.white, 0.7),
+    color: alpha(theme.palette.text.primary, 0.7),
   },
-})(Typography);
+}))(Typography);
 
 const StatsItem: React.FC<StatsItemProps> = ({
   caption,


### PR DESCRIPTION
## Change description

CET-6941
Fix for `Stats` component label color on light theme.

## Screenshots BEFORE:
![image](https://github.com/cortexapps/backstage-plugin/assets/6973407/06b39738-132d-49ae-8412-233930513f0a)

## Screenshots AFTER:
<img width="1448" alt="image" src="https://github.com/cortexapps/backstage-plugin/assets/6973407/a4ded594-de0a-46a5-86fd-d63190191123">
<img width="1475" alt="image" src="https://github.com/cortexapps/backstage-plugin/assets/6973407/3d49c2d2-4315-4fa8-95ca-7302c06cd293">
