### PR TITLE
CET-7027 use full backstage ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@
 
 ### 2.4.4
 
-- Add support for non ISO-8859-1 characters in request headers to the Cortex API. This fixes authentication for users
-  with these characters in their name.
+- Add support for non ISO-8859-1 characters in request headers to the Cortex API. This fixes authentication for users with these characters in their name.
 
 ### 2.4.3
 
@@ -33,8 +32,7 @@
 
 ### 2.4.0
 
-- Adds the ability to filter which entities get sent from Backstage to Cortex (
-  via [backstage-plugin-extensions)](https://github.com/cortexapps/backstage-plugin-extensions)
+- Adds the ability to filter which entities get sent from Backstage to Cortex (via [backstage-plugin-extensions)](https://github.com/cortexapps/backstage-plugin-extensions)
 
 ### 2.3.3
 
@@ -54,8 +52,7 @@
 
 ### 2.2.0
 
-- Adds ability to add badges to Scorecards based on extension criteria (
-  via [backstage-plugin-extensions)](https://github.com/cortexapps/backstage-plugin-extensions)
+- Adds ability to add badges to Scorecards based on extension criteria (via [backstage-plugin-extensions)](https://github.com/cortexapps/backstage-plugin-extensions)
 - Adds “Back” link to the Scorecard service page
 - Adds Help Links page to Settings with a configurable set of links
 
@@ -75,8 +72,7 @@
 
 ### 2.0.4
 
-- Add support for custom Scorecard support order (
-  via [backstage-plugin-extensions](https://github.com/cortexapps/backstage-plugin-extensions))
+- Add support for custom Scorecard support order (via [backstage-plugin-extensions](https://github.com/cortexapps/backstage-plugin-extensions))
 
 ### 2.0.3
 
@@ -92,5 +88,4 @@
 
 - Copy updates
 
-**NOTE:** 2.0.0 and prior are not documented.
-See [commit history](https://github.com/cortexapps/backstage-plugin/commits/master) for details.
+**NOTE:** 2.0.0 and prior are not documented. See [commit history](https://github.com/cortexapps/backstage-plugin/commits/master) for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2.5.2
 
-- Fix using full Entity Ref. This fixes an issue where the plugin was not resolving entity Kind and Namespace.
+- Fix entity links by applying the correct `kind` instead of always assuming they are `Component`s
 
 ### 2.5.1
 
@@ -16,7 +16,8 @@
 
 ### 2.4.4
 
-- Add support for non ISO-8859-1 characters in request headers to the Cortex API. This fixes authentication for users with these characters in their name.
+- Add support for non ISO-8859-1 characters in request headers to the Cortex API. This fixes authentication for users
+  with these characters in their name.
 
 ### 2.4.3
 
@@ -32,7 +33,8 @@
 
 ### 2.4.0
 
-- Adds the ability to filter which entities get sent from Backstage to Cortex (via [backstage-plugin-extensions)](https://github.com/cortexapps/backstage-plugin-extensions)
+- Adds the ability to filter which entities get sent from Backstage to Cortex (
+  via [backstage-plugin-extensions)](https://github.com/cortexapps/backstage-plugin-extensions)
 
 ### 2.3.3
 
@@ -52,7 +54,8 @@
 
 ### 2.2.0
 
-- Adds ability to add badges to Scorecards based on extension criteria (via [backstage-plugin-extensions)](https://github.com/cortexapps/backstage-plugin-extensions)
+- Adds ability to add badges to Scorecards based on extension criteria (
+  via [backstage-plugin-extensions)](https://github.com/cortexapps/backstage-plugin-extensions)
 - Adds “Back” link to the Scorecard service page
 - Adds Help Links page to Settings with a configurable set of links
 
@@ -72,7 +75,8 @@
 
 ### 2.0.4
 
-- Add support for custom Scorecard support order (via [backstage-plugin-extensions](https://github.com/cortexapps/backstage-plugin-extensions))
+- Add support for custom Scorecard support order (
+  via [backstage-plugin-extensions](https://github.com/cortexapps/backstage-plugin-extensions))
 
 ### 2.0.3
 
@@ -88,4 +92,5 @@
 
 - Copy updates
 
-**NOTE:** 2.0.0 and prior are not documented. See [commit history](https://github.com/cortexapps/backstage-plugin/commits/master) for details.
+**NOTE:** 2.0.0 and prior are not documented.
+See [commit history](https://github.com/cortexapps/backstage-plugin/commits/master) for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.5.2
+
+- Fix using full Entity Ref. This fixes an issue where the plugin was not resolving entity Kind and Namespace.
+
 ### 2.5.1
 
 - Fix label color (light theme)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/Homepage/HomepageInsightCard.tsx
+++ b/src/components/Homepage/HomepageInsightCard.tsx
@@ -61,7 +61,7 @@ export const HomepageInsightCard = ({
       );
 
       const entityRef = {
-        kind: 'Component',
+        kind: entity?.definition?.kind || 'Component',
         namespace: 'default',
         name: entity?.name || '',
       };
@@ -112,7 +112,7 @@ export const HomepageInsightCard = ({
         : '';
 
       const entityRef = {
-        kind: 'Component',
+        kind: entity?.definition?.kind || 'Component',
         namespace: 'default',
         name: entity?.name || '',
       };

--- a/src/components/Homepage/HomepageInsightCard.tsx
+++ b/src/components/Homepage/HomepageInsightCard.tsx
@@ -62,8 +62,8 @@ export const HomepageInsightCard = ({
 
       const entityRef = {
         kind: entity?.definition?.kind || 'Component',
-        namespace: 'default',
-        name: entity?.name || '',
+        namespace: entity?.definition?.namespace || 'default',
+        name: entity?.definition?.name || entity?.codeTag,
       };
 
       return (
@@ -113,8 +113,8 @@ export const HomepageInsightCard = ({
 
       const entityRef = {
         kind: entity?.definition?.kind || 'Component',
-        namespace: 'default',
-        name: entity?.name || '',
+        namespace: entity?.definition?.namespace || 'default',
+        name: entity?.definition?.name || entity?.codeTag,
       };
 
       return (

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
@@ -26,7 +26,7 @@ import { useEntitiesByTag } from '../../../utils/hooks';
 import { InitiativeMetadataCard } from './InitiativeMetadataCard';
 import { InitiativeFailingTab } from './InitiativeFailingTab';
 import { InitiativePassingTab } from './InitiativePassingTab';
-import { InitiativeLevelsTab } from './InitiativeLevelsTab/InitiativeLevelsTab';
+import { InitiativeLevelsTab } from './InitiativeLevelsTab';
 import { InitiativeRulesTab } from './InitiativeRulesTab';
 import { isEmpty, isNil, keyBy } from 'lodash';
 import { InitiativeFilterDialog } from './InitativeFilterDialog';

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
@@ -77,7 +77,7 @@ export const InitiativeDetailsPage = () => {
         })
         ?.filter(filter) ?? []
     );
-  }, [initiative, filter]);
+  }, [initiative, filter, entitiesByTag]);
 
   const filteredActionItems = useMemo(() => {
     if (isNil(actionItems)) {

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
@@ -28,10 +28,9 @@ import { InitiativeFailingTab } from './InitiativeFailingTab';
 import { InitiativePassingTab } from './InitiativePassingTab';
 import { InitiativeLevelsTab } from './InitiativeLevelsTab';
 import { InitiativeRulesTab } from './InitiativeRulesTab';
-import { isEmpty, isNil, keyBy } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 import { InitiativeFilterDialog } from './InitativeFilterDialog';
 import { InitiativeFilter } from './InitativeFilterDialog/InitiativeFilterDialogUtils';
-import { entityComponentRef } from '../../../utils/ComponentUtils';
 
 enum InitiativeDetailsTab {
   'Failing' = 'Failing',
@@ -60,24 +59,14 @@ export const InitiativeDetailsPage = () => {
   }, []);
 
   const { entitiesByTag, loading: loadingEntities } = useEntitiesByTag();
-  const entitiesByComponentRef = useMemo(() => {
-    return keyBy(Object.values(entitiesByTag), entity =>
-      entityComponentRef(entity),
-    );
-  }, [entitiesByTag]);
 
   const [initiative, actionItems] = value ?? [undefined, undefined];
 
   const filteredComponentRefs = useMemo(() => {
     return (
-      initiative?.scores
-        ?.map(score => {
-          const entity = entitiesByTag[score.entityTag];
-          return entityComponentRef(entity);
-        })
-        ?.filter(filter) ?? []
+      initiative?.scores?.map(score => score.entityTag)?.filter(filter) ?? []
     );
-  }, [initiative, filter, entitiesByTag]);
+  }, [initiative, filter]);
 
   const filteredActionItems = useMemo(() => {
     if (isNil(actionItems)) {
@@ -120,7 +109,7 @@ export const InitiativeDetailsPage = () => {
         return (
           <InitiativeFailingTab
             actionItems={filteredActionItems}
-            entitiesByComponentRef={entitiesByComponentRef}
+            entitiesByTag={entitiesByTag}
             numRules={initiative.rules.length}
             scorecardId={initiative.scorecard.id}
           />
@@ -130,7 +119,7 @@ export const InitiativeDetailsPage = () => {
           <InitiativePassingTab
             actionItems={actionItems}
             componentRefs={filteredComponentRefs}
-            entitiesByComponentRef={entitiesByComponentRef}
+            entitiesByTag={entitiesByTag}
             numRules={initiative.rules.length}
             scorecardId={initiative.scorecard.id}
           />

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
@@ -28,9 +28,10 @@ import { InitiativeFailingTab } from './InitiativeFailingTab';
 import { InitiativePassingTab } from './InitiativePassingTab';
 import { InitiativeLevelsTab } from './InitiativeLevelsTab/InitiativeLevelsTab';
 import { InitiativeRulesTab } from './InitiativeRulesTab';
-import { isEmpty, isNil } from 'lodash';
+import { isEmpty, isNil, keyBy } from 'lodash';
 import { InitiativeFilterDialog } from './InitativeFilterDialog';
 import { InitiativeFilter } from './InitativeFilterDialog/InitiativeFilterDialogUtils';
+import { entityComponentRef } from '../../../utils/ComponentUtils';
 
 enum InitiativeDetailsTab {
   'Failing' = 'Failing',
@@ -59,12 +60,22 @@ export const InitiativeDetailsPage = () => {
   }, []);
 
   const { entitiesByTag, loading: loadingEntities } = useEntitiesByTag();
+  const entitiesByComponentRef = useMemo(() => {
+    return keyBy(Object.values(entitiesByTag), entity =>
+      entityComponentRef(entity),
+    );
+  }, [entitiesByTag]);
 
   const [initiative, actionItems] = value ?? [undefined, undefined];
 
   const filteredComponentRefs = useMemo(() => {
     return (
-      initiative?.scores?.map(score => score.entityTag)?.filter(filter) ?? []
+      initiative?.scores
+        ?.map(score => {
+          const entity = entitiesByTag[score.entityTag];
+          return entityComponentRef(entity);
+        })
+        ?.filter(filter) ?? []
     );
   }, [initiative, filter]);
 
@@ -109,7 +120,7 @@ export const InitiativeDetailsPage = () => {
         return (
           <InitiativeFailingTab
             actionItems={filteredActionItems}
-            entitiesByTag={entitiesByTag}
+            entitiesByComponentRef={entitiesByComponentRef}
             numRules={initiative.rules.length}
             scorecardId={initiative.scorecard.id}
           />
@@ -119,7 +130,7 @@ export const InitiativeDetailsPage = () => {
           <InitiativePassingTab
             actionItems={actionItems}
             componentRefs={filteredComponentRefs}
-            entitiesByTag={entitiesByTag}
+            entitiesByComponentRef={entitiesByComponentRef}
             numRules={initiative.rules.length}
             scorecardId={initiative.scorecard.id}
           />

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeFailingTab/InitiativeFailingTab.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeFailingTab/InitiativeFailingTab.tsx
@@ -18,7 +18,6 @@ import React, { useMemo } from 'react';
 import { InitiativeActionItem } from '../../../../api/types';
 import { ServiceNameAndRulesColumn } from './ServiceNameAndRulesColumn';
 import { EmptyState, InfoCard, Table as BSTable, TableColumn, } from '@backstage/core-components';
-import { StringIndexable } from '../../../ReportsPage/HeatmapPage/HeatmapUtils';
 import { HomepageEntity } from '../../../../api/userInsightTypes';
 import { Box, ThemeProvider, Typography } from '@material-ui/core';
 import { defaultComponentRefContext, entityComponentRef, } from '../../../../utils/ComponentUtils';
@@ -36,7 +35,7 @@ import { size } from 'lodash';
 interface InitiativeFailingTabProps {
   actionItems: InitiativeActionItem[];
   defaultPageSize?: number;
-  entitiesByTag: StringIndexable<HomepageEntity>;
+  entitiesByTag: Record<string, HomepageEntity>;
   numRules?: number;
   scorecardId: number;
 }

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeFailingTab/InitiativeFailingTab.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeFailingTab/InitiativeFailingTab.tsx
@@ -17,12 +17,7 @@
 import React, { useMemo } from 'react';
 import { InitiativeActionItem } from '../../../../api/types';
 import { ServiceNameAndRulesColumn } from './ServiceNameAndRulesColumn';
-import {
-  TableColumn,
-  Table as BSTable,
-  EmptyState,
-  InfoCard,
-} from '@backstage/core-components';
+import { EmptyState, InfoCard, Table as BSTable, TableColumn, } from '@backstage/core-components';
 import { StringIndexable } from '../../../ReportsPage/HeatmapPage/HeatmapUtils';
 import { HomepageEntity } from '../../../../api/userInsightTypes';
 import { Box, ThemeProvider, Typography } from '@material-ui/core';
@@ -32,8 +27,8 @@ import { humanizeAnyEntityRef } from '../../../../utils/types';
 import { LinearProgressWithLabel } from '../../../Common/LinearProgressWithLabel';
 import { percentify } from '../../../../utils/NumberUtils';
 import {
-  InitiativeFailingTabRowProps,
   failingTabTheme,
+  InitiativeFailingTabRowProps,
   useInitiativeFailingTabStyle,
 } from './InitiativeFailingTabConfig';
 import { size } from 'lodash';
@@ -41,7 +36,7 @@ import { size } from 'lodash';
 interface InitiativeFailingTabProps {
   actionItems: InitiativeActionItem[];
   defaultPageSize?: number;
-  entitiesByTag: StringIndexable<HomepageEntity>;
+  entitiesByComponentRef: StringIndexable<HomepageEntity>;
   numRules?: number;
   scorecardId: number;
 }
@@ -49,7 +44,7 @@ interface InitiativeFailingTabProps {
 export const InitiativeFailingTab: React.FC<InitiativeFailingTabProps> = ({
   actionItems,
   defaultPageSize = 15,
-  entitiesByTag,
+  entitiesByComponentRef,
   numRules = 2,
   scorecardId,
 }) => {
@@ -68,7 +63,7 @@ export const InitiativeFailingTab: React.FC<InitiativeFailingTabProps> = ({
           defaultComponentRefContext,
         );
 
-        const { name, description } = entitiesByTag[componentRef];
+        const { name, description } = entitiesByComponentRef[componentRef];
         const serviceActionItems = failingComponents[componentRef];
 
         return {
@@ -82,7 +77,7 @@ export const InitiativeFailingTab: React.FC<InitiativeFailingTabProps> = ({
       })
       .sort((left, right) => left.actionItems.length - right.actionItems.length)
       .sort((left, right) => left.tag.localeCompare(right.tag));
-  }, [entitiesByTag, failingComponents, numRules]);
+  }, [entitiesByComponentRef, failingComponents, numRules]);
 
   const showPagination = useMemo(() => {
     return size(failingComponents) > defaultPageSize;

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeFailingTab/InitiativeFailingTab.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeFailingTab/InitiativeFailingTab.tsx
@@ -21,7 +21,7 @@ import { EmptyState, InfoCard, Table as BSTable, TableColumn, } from '@backstage
 import { StringIndexable } from '../../../ReportsPage/HeatmapPage/HeatmapUtils';
 import { HomepageEntity } from '../../../../api/userInsightTypes';
 import { Box, ThemeProvider, Typography } from '@material-ui/core';
-import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
+import { defaultComponentRefContext, entityComponentRef, } from '../../../../utils/ComponentUtils';
 import { groupByString } from '../../../../utils/collections';
 import { humanizeAnyEntityRef } from '../../../../utils/types';
 import { LinearProgressWithLabel } from '../../../Common/LinearProgressWithLabel';
@@ -36,7 +36,7 @@ import { size } from 'lodash';
 interface InitiativeFailingTabProps {
   actionItems: InitiativeActionItem[];
   defaultPageSize?: number;
-  entitiesByComponentRef: StringIndexable<HomepageEntity>;
+  entitiesByTag: StringIndexable<HomepageEntity>;
   numRules?: number;
   scorecardId: number;
 }
@@ -44,7 +44,7 @@ interface InitiativeFailingTabProps {
 export const InitiativeFailingTab: React.FC<InitiativeFailingTabProps> = ({
   actionItems,
   defaultPageSize = 15,
-  entitiesByComponentRef,
+  entitiesByTag,
   numRules = 2,
   scorecardId,
 }) => {
@@ -63,7 +63,7 @@ export const InitiativeFailingTab: React.FC<InitiativeFailingTabProps> = ({
           defaultComponentRefContext,
         );
 
-        const { name, description } = entitiesByComponentRef[componentRef];
+        const { name, description } = entitiesByTag[componentRef];
         const serviceActionItems = failingComponents[componentRef];
 
         return {
@@ -77,7 +77,7 @@ export const InitiativeFailingTab: React.FC<InitiativeFailingTabProps> = ({
       })
       .sort((left, right) => left.actionItems.length - right.actionItems.length)
       .sort((left, right) => left.tag.localeCompare(right.tag));
-  }, [entitiesByComponentRef, failingComponents, numRules]);
+  }, [entitiesByTag, failingComponents, numRules]);
 
   const showPagination = useMemo(() => {
     return size(failingComponents) > defaultPageSize;
@@ -91,7 +91,13 @@ export const InitiativeFailingTab: React.FC<InitiativeFailingTabProps> = ({
         width: '60%',
         render: (data: InitiativeFailingTabRowProps) => {
           return (
-            <ServiceNameAndRulesColumn {...data} scorecardId={scorecardId} />
+            <ServiceNameAndRulesColumn
+              {...data}
+              componentRef={entityComponentRef(
+                entitiesByTag[data.componentRef],
+              )}
+              scorecardId={scorecardId}
+            />
           );
         },
         customSort: (

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeFailingTab/InitiativeFailingTab.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeFailingTab/InitiativeFailingTab.tsx
@@ -94,7 +94,8 @@ export const InitiativeFailingTab: React.FC<InitiativeFailingTabProps> = ({
             <ServiceNameAndRulesColumn
               {...data}
               componentRef={entityComponentRef(
-                entitiesByTag[data.componentRef],
+                entitiesByTag,
+                data.componentRef,
               )}
               scorecardId={scorecardId}
             />

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeFailingTab/InitiativeFailingTab.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeFailingTab/InitiativeFailingTab.tsx
@@ -169,7 +169,7 @@ export const InitiativeFailingTab: React.FC<InitiativeFailingTabProps> = ({
         },
       },
     ],
-    [classes, numRules, scorecardId],
+    [classes, numRules, scorecardId, entitiesByTag],
   );
 
   if (data.length === 0) {

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativePassingTab/InitiativePassingTab.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativePassingTab/InitiativePassingTab.tsx
@@ -19,7 +19,7 @@ import { EmptyState, InfoCard, Table as BSTable, TableColumn, } from '@backstage
 import { StringIndexable } from '../../../ReportsPage/HeatmapPage/HeatmapUtils';
 import { HomepageEntity } from '../../../../api/userInsightTypes';
 import { Box, ThemeProvider, Typography } from '@material-ui/core';
-import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
+import { defaultComponentRefContext, entityComponentRef, } from '../../../../utils/ComponentUtils';
 import { humanizeAnyEntityRef } from '../../../../utils/types';
 import { LinearProgressWithLabel } from '../../../Common/LinearProgressWithLabel';
 import {
@@ -34,7 +34,7 @@ interface InitiativePassingTabProps {
   actionItems: InitiativeActionItem[];
   componentRefs: string[];
   defaultPageSize?: number;
-  entitiesByComponentRef: StringIndexable<HomepageEntity>;
+  entitiesByTag: StringIndexable<HomepageEntity>;
   numRules: number;
   scorecardId: number;
 }
@@ -43,7 +43,7 @@ export const InitiativePassingTab: React.FC<InitiativePassingTabProps> = ({
   actionItems,
   componentRefs,
   defaultPageSize = 15,
-  entitiesByComponentRef,
+  entitiesByTag,
   numRules = 2,
   scorecardId,
 }) => {
@@ -66,7 +66,7 @@ export const InitiativePassingTab: React.FC<InitiativePassingTabProps> = ({
           componentRef,
           defaultComponentRefContext,
         );
-        const { name, description } = entitiesByComponentRef[componentRef];
+        const { name, description } = entitiesByTag[componentRef];
 
         return {
           componentRef,
@@ -76,7 +76,7 @@ export const InitiativePassingTab: React.FC<InitiativePassingTabProps> = ({
         };
       })
       .sort((left, right) => left.tag.localeCompare(right.tag));
-  }, [entitiesByComponentRef, passingComponents]);
+  }, [entitiesByTag, passingComponents]);
 
   const showPagination = useMemo(
     () => componentRefs.length > defaultPageSize,
@@ -90,7 +90,15 @@ export const InitiativePassingTab: React.FC<InitiativePassingTabProps> = ({
         title: 'Service name',
         width: '60%',
         render: (data: InitiativePassingTabRowProps) => {
-          return <ServiceNameColumn {...data} scorecardId={scorecardId} />;
+          return (
+            <ServiceNameColumn
+              {...data}
+              componentRef={entityComponentRef(
+                entitiesByTag[data.componentRef],
+              )}
+              scorecardId={scorecardId}
+            />
+          );
         },
         customSort: (
           data1: InitiativePassingTabRowProps,

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativePassingTab/InitiativePassingTab.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativePassingTab/InitiativePassingTab.tsx
@@ -94,7 +94,8 @@ export const InitiativePassingTab: React.FC<InitiativePassingTabProps> = ({
             <ServiceNameColumn
               {...data}
               componentRef={entityComponentRef(
-                entitiesByTag[data.componentRef],
+                entitiesByTag,
+                data.componentRef,
               )}
               scorecardId={scorecardId}
             />

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativePassingTab/InitiativePassingTab.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativePassingTab/InitiativePassingTab.tsx
@@ -162,7 +162,7 @@ export const InitiativePassingTab: React.FC<InitiativePassingTabProps> = ({
         },
       },
     ],
-    [classes, numRules, scorecardId],
+    [classes, numRules, scorecardId, entitiesByTag],
   );
 
   if (data.length === 0) {

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativePassingTab/InitiativePassingTab.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativePassingTab/InitiativePassingTab.tsx
@@ -15,12 +15,7 @@
  */
 
 import React, { useMemo } from 'react';
-import {
-  TableColumn,
-  Table as BSTable,
-  EmptyState,
-  InfoCard,
-} from '@backstage/core-components';
+import { EmptyState, InfoCard, Table as BSTable, TableColumn, } from '@backstage/core-components';
 import { StringIndexable } from '../../../ReportsPage/HeatmapPage/HeatmapUtils';
 import { HomepageEntity } from '../../../../api/userInsightTypes';
 import { Box, ThemeProvider, Typography } from '@material-ui/core';
@@ -39,7 +34,7 @@ interface InitiativePassingTabProps {
   actionItems: InitiativeActionItem[];
   componentRefs: string[];
   defaultPageSize?: number;
-  entitiesByTag: StringIndexable<HomepageEntity>;
+  entitiesByComponentRef: StringIndexable<HomepageEntity>;
   numRules: number;
   scorecardId: number;
 }
@@ -48,7 +43,7 @@ export const InitiativePassingTab: React.FC<InitiativePassingTabProps> = ({
   actionItems,
   componentRefs,
   defaultPageSize = 15,
-  entitiesByTag,
+  entitiesByComponentRef,
   numRules = 2,
   scorecardId,
 }) => {
@@ -71,7 +66,7 @@ export const InitiativePassingTab: React.FC<InitiativePassingTabProps> = ({
           componentRef,
           defaultComponentRefContext,
         );
-        const { name, description } = entitiesByTag[componentRef];
+        const { name, description } = entitiesByComponentRef[componentRef];
 
         return {
           componentRef,
@@ -81,7 +76,7 @@ export const InitiativePassingTab: React.FC<InitiativePassingTabProps> = ({
         };
       })
       .sort((left, right) => left.tag.localeCompare(right.tag));
-  }, [entitiesByTag, passingComponents]);
+  }, [entitiesByComponentRef, passingComponents]);
 
   const showPagination = useMemo(
     () => componentRefs.length > defaultPageSize,

--- a/src/components/ReportsPage/HeatmapPage/LevelsInfoCell.tsx
+++ b/src/components/ReportsPage/HeatmapPage/LevelsInfoCell.tsx
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import {
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  TableCell,
-  Typography,
-  makeStyles,
-} from '@material-ui/core';
+import { Accordion, AccordionDetails, AccordionSummary, makeStyles, TableCell, Typography, } from '@material-ui/core';
 import { ExpandMore } from '@material-ui/icons';
 import { EntityRefLink } from '@backstage/plugin-catalog-react';
 import { parseEntityRef } from '@backstage/catalog-model';
@@ -31,6 +24,8 @@ import { defaultComponentRefContext } from '../../../utils/ComponentUtils';
 
 import { ScorecardServiceScore } from '../../../api/types';
 import { BackstageTheme } from '@backstage/theme';
+import { StringIndexable } from './HeatmapUtils';
+import { HomepageEntity } from '../../../api/userInsightTypes';
 
 const useStyles = makeStyles<BackstageTheme>(_ => ({
   componentList: {
@@ -39,11 +34,16 @@ const useStyles = makeStyles<BackstageTheme>(_ => ({
 }));
 
 interface LevelsInfoCellProps {
+  entitiesByTag: StringIndexable<HomepageEntity>;
   identifier: string;
   scores: ScorecardServiceScore[];
 }
 
-export const LevelsInfoCell = ({ identifier, scores }: LevelsInfoCellProps) => {
+export const LevelsInfoCell = ({
+  identifier,
+  scores,
+  entitiesByTag,
+}: LevelsInfoCellProps) => {
   const classes = useStyles();
   return (
     <TableCell>
@@ -62,7 +62,7 @@ export const LevelsInfoCell = ({ identifier, scores }: LevelsInfoCellProps) => {
               <li key={`LevelService-${identifier}-${score.serviceId}`}>
                 <EntityRefLink
                   entityRef={parseEntityRef(
-                    score.componentRef,
+                    entitiesByTag[score.componentRef],
                     defaultComponentRefContext,
                   )}
                 />

--- a/src/components/ReportsPage/HeatmapPage/LevelsInfoCell.tsx
+++ b/src/components/ReportsPage/HeatmapPage/LevelsInfoCell.tsx
@@ -24,7 +24,6 @@ import { defaultComponentRefContext } from '../../../utils/ComponentUtils';
 
 import { ScorecardServiceScore } from '../../../api/types';
 import { BackstageTheme } from '@backstage/theme';
-import { StringIndexable } from './HeatmapUtils';
 import { HomepageEntity } from '../../../api/userInsightTypes';
 
 const useStyles = makeStyles<BackstageTheme>(_ => ({
@@ -34,7 +33,7 @@ const useStyles = makeStyles<BackstageTheme>(_ => ({
 }));
 
 interface LevelsInfoCellProps {
-  entitiesByTag: StringIndexable<HomepageEntity>;
+  entitiesByTag: Record<string, HomepageEntity>;
   identifier: string;
   scores: ScorecardServiceScore[];
 }

--- a/src/components/ReportsPage/HeatmapPage/Tables/AllScorecardHeatmapTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/AllScorecardHeatmapTable.tsx
@@ -15,7 +15,7 @@
  */
 import React, { useMemo } from 'react';
 import { mean as _average, round as _round } from 'lodash';
-import { Table, TableBody, TableRow, TableCell } from '@material-ui/core';
+import { Table, TableBody, TableCell, TableRow } from '@material-ui/core';
 import { EntityRefLink } from '@backstage/plugin-catalog-react';
 import { parseEntityRef } from '@backstage/catalog-model';
 
@@ -78,7 +78,7 @@ export const AllScorecardsHeatmapTable = ({
                 ) : (
                   <EntityRefLink
                     entityRef={parseEntityRef(
-                      groupScore.identifier!!,
+                      entitiesByTag[groupScore.identifier!!]?.definition,
                       defaultComponentRefContext,
                     )}
                     title={entitiesByTag[groupScore.identifier!!]?.name}

--- a/src/components/ReportsPage/HeatmapPage/Tables/HeatmapTableByService.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/HeatmapTableByService.tsx
@@ -21,7 +21,7 @@ import { ScorecardServiceScore } from '../../../../api/types';
 import TableBody from '@material-ui/core/TableBody/TableBody';
 import { EntityRefLink } from '@backstage/plugin-catalog-react';
 import { parseEntityRef } from '@backstage/catalog-model';
-import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
+import { defaultComponentRefContext, entityComponentRef, } from '../../../../utils/ComponentUtils';
 import { HeatmapCell } from '../HeatmapCell';
 import { getAverageRuleScores, StringIndexable } from '../HeatmapUtils';
 import { mean as _average } from 'lodash';
@@ -57,7 +57,7 @@ export const HeatmapTableByService = ({
               <TableCell>
                 <EntityRefLink
                   entityRef={parseEntityRef(
-                    firstScore.componentRef,
+                    entityComponentRef(entitiesByTag[firstScore.componentRef]),
                     defaultComponentRefContext,
                   )}
                   title={entitiesByTag[firstScore.componentRef]?.name}

--- a/src/components/ReportsPage/HeatmapPage/Tables/HeatmapTableByService.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/HeatmapTableByService.tsx
@@ -57,7 +57,7 @@ export const HeatmapTableByService = ({
               <TableCell>
                 <EntityRefLink
                   entityRef={parseEntityRef(
-                    entityComponentRef(entitiesByTag[firstScore.componentRef]),
+                    entityComponentRef(entitiesByTag, firstScore.componentRef),
                     defaultComponentRefContext,
                   )}
                   title={entitiesByTag[firstScore.componentRef]?.name}

--- a/src/components/ReportsPage/HeatmapPage/Tables/LevelsDrivenTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/LevelsDrivenTable.tsx
@@ -68,7 +68,8 @@ export const LevelsDrivenTable = ({
                   <EntityRefLink
                     entityRef={parseEntityRef(
                       entityComponentRef(
-                        entitiesByTag[firstScore.componentRef],
+                        entitiesByTag,
+                        firstScore.componentRef,
                       ),
                       defaultComponentRefContext,
                     )}

--- a/src/components/ReportsPage/HeatmapPage/Tables/LevelsDrivenTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/LevelsDrivenTable.tsx
@@ -14,37 +14,28 @@
  * limitations under the License.
  */
 import React from 'react';
-import {
-  Table,
-  TableBody,
-  TableRow,
-  TableCell,
-  Typography,
-} from '@material-ui/core';
+import { Table, TableBody, TableCell, TableRow, Typography, } from '@material-ui/core';
 import { EntityRefLink } from '@backstage/plugin-catalog-react';
 import { parseEntityRef } from '@backstage/catalog-model';
 
-import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
+import { defaultComponentRefContext, entityComponentRef, } from '../../../../utils/ComponentUtils';
 import { HeatmapTableHeader } from './HeatmapTableHeader';
 import { LevelsInfoCell } from '../LevelsInfoCell';
-import {
-  getServicesInLevelsFromScores,
-  StringIndexable,
-} from '../HeatmapUtils';
+import { getServicesInLevelsFromScores, StringIndexable, } from '../HeatmapUtils';
 
 import { GroupByOption, ScorecardServiceScore } from '../../../../api/types';
 import { HomepageEntity } from '../../../../api/userInsightTypes';
 
 interface LevelsDrivenTableProps {
   data: StringIndexable<ScorecardServiceScore[]>;
-  entititesByTag: StringIndexable<HomepageEntity>;
+  entitiesByTag: StringIndexable<HomepageEntity>;
   groupBy: GroupByOption;
   levels: string[];
 }
 
 export const LevelsDrivenTable = ({
   data,
-  entititesByTag,
+  entitiesByTag,
   groupBy,
   levels,
 }: LevelsDrivenTableProps) => {
@@ -76,10 +67,12 @@ export const LevelsDrivenTable = ({
                 <TableCell>
                   <EntityRefLink
                     entityRef={parseEntityRef(
-                      firstScore.componentRef,
+                      entityComponentRef(
+                        entitiesByTag[firstScore.componentRef],
+                      ),
                       defaultComponentRefContext,
                     )}
-                    title={entititesByTag[firstScore.componentRef]?.name}
+                    title={entitiesByTag[firstScore.componentRef]?.name}
                   />
                 </TableCell>
               )}
@@ -93,6 +86,7 @@ export const LevelsDrivenTable = ({
               {scores.map((score, idx) => (
                 <LevelsInfoCell
                   key={`LevelsInfoCell-${key}-${idx}`}
+                  entitiesByTag={entitiesByTag}
                   identifier={key}
                   scores={score}
                 />

--- a/src/components/ReportsPage/HeatmapPage/Tables/LevelsDrivenTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/LevelsDrivenTable.tsx
@@ -28,7 +28,7 @@ import { HomepageEntity } from '../../../../api/userInsightTypes';
 
 interface LevelsDrivenTableProps {
   data: StringIndexable<ScorecardServiceScore[]>;
-  entitiesByTag: StringIndexable<HomepageEntity>;
+  entitiesByTag: Record<string, HomepageEntity>;
   groupBy: GroupByOption;
   levels: string[];
 }

--- a/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
@@ -21,19 +21,10 @@ import { HeatmapTableByGroup } from './HeatmapTableByGroup';
 import { HeatmapTableByLevels } from './HeatmapTableByLevels';
 import { HeatmapTableByService } from './HeatmapTableByService';
 import { LevelsDrivenTable } from './LevelsDrivenTable';
-import {
-  getScorecardServiceScoresByGroupByOption,
-  getSortedRuleNames,
-  StringIndexable,
-} from '../HeatmapUtils';
+import { getScorecardServiceScoresByGroupByOption, getSortedRuleNames, StringIndexable, } from '../HeatmapUtils';
 import { getSortedLadderLevelNames } from '../../../../utils/ScorecardLadderUtils';
 
-import {
-  GroupByOption,
-  HeaderType,
-  ScorecardLadder,
-  ScorecardServiceScore,
-} from '../../../../api/types';
+import { GroupByOption, HeaderType, ScorecardLadder, ScorecardServiceScore, } from '../../../../api/types';
 import { HomepageEntity } from '../../../../api/userInsightTypes';
 
 interface SingleScorecardHeatmapTableProps {
@@ -76,7 +67,7 @@ export const SingleScorecardHeatmapTable = ({
       return (
         <LevelsDrivenTable
           data={data}
-          entititesByTag={entitiesByTag}
+          entitiesByTag={entitiesByTag}
           groupBy={groupBy}
           levels={headers}
         />

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetails.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardDetails.tsx
@@ -15,23 +15,12 @@
  */
 import { Content } from '@backstage/core-components';
 import React, { useMemo, useState } from 'react';
-import {
-  Scorecard,
-  ScorecardLadder,
-  ScorecardRuleExemptionResult,
-  ScorecardServiceScore,
-} from '../../../api/types';
+import { Scorecard, ScorecardLadder, ScorecardRuleExemptionResult, ScorecardServiceScore, } from '../../../api/types';
 import { Box, Button, Grid, Tab, Tabs } from '@material-ui/core';
 import { ScorecardMetadataCard } from './ScorecardMetadataCard';
-import {
-  ScorecardLadderRulesCard,
-  ScorecardScoresRulesCard,
-} from './ScorecardRulesTab';
+import { ScorecardLadderRulesCard, ScorecardScoresRulesCard, } from './ScorecardRulesTab';
 import { Predicate } from '../../../utils/types';
-import {
-  ScorecardLadderStatsCard,
-  ScorecardScoresStatsCard,
-} from './ScorecardStatsCard';
+import { ScorecardLadderStatsCard, ScorecardScoresStatsCard, } from './ScorecardStatsCard';
 import { StringIndexable } from '../../ReportsPage/HeatmapPage/HeatmapUtils';
 import { HomepageEntity } from '../../../api/userInsightTypes';
 import CopyCsvButton from './CopyCsvButton';
@@ -108,6 +97,7 @@ export const ScorecardDetails = ({
       case ScorecardDetailsTab.RuleExemptions:
         return (
           <ScorecardRuleExemptionsTab
+            entitiesByTag={entitiesByTag}
             ruleExemptions={ruleExemptions}
             scorecard={scorecard}
             scores={scores}

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardRuleExemptionsTab/ScorecardRuleExemptionsTab.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardRuleExemptionsTab/ScorecardRuleExemptionsTab.tsx
@@ -14,25 +14,21 @@
  * limitations under the License.
  */
 import React, { useMemo } from 'react';
-import {
-  Rule,
-  Scorecard,
-  ScorecardRuleExemptionResult,
-  ScorecardServiceScore,
-} from '../../../../api/types';
-import { Box, Tooltip, Typography, makeStyles } from '@material-ui/core';
+import { Rule, Scorecard, ScorecardRuleExemptionResult, ScorecardServiceScore, } from '../../../../api/types';
+import { Box, makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { getRuleTitle } from '../../../../utils/ScorecardRules';
 import { RuleExemptionStatus } from './RuleExemptionStatus';
 import { CortexInfoCard } from '../../../Common/CortexInfoCard';
-import {
-  getExpirationText,
-  getIsActive,
-} from './ScorecardRuleExemptionsTabUtils';
+import { getExpirationText, getIsActive, } from './ScorecardRuleExemptionsTabUtils';
 import ScorecardRuleExemptionTooltip from './ScorecardRuleExemptionTooltip';
 import { ScorecardServiceRefLink } from '../../../ScorecardServiceRefLink';
 import { isEmpty } from 'lodash';
+import { StringIndexable } from '../../../ReportsPage/HeatmapPage/HeatmapUtils';
+import { HomepageEntity } from '../../../../api/userInsightTypes';
+import { entityComponentRef } from '../../../../utils/ComponentUtils';
 
 interface ScorecardRuleExemptionsTabProps {
+  entitiesByTag: StringIndexable<HomepageEntity>;
   ruleExemptions: ScorecardRuleExemptionResult['scorecardRuleExemptions'];
   scorecard: Scorecard;
   scores: ScorecardServiceScore[];
@@ -45,6 +41,7 @@ const useRuleExemptionsTabStyles = makeStyles(() => ({
 }));
 
 export const ScorecardRuleExemptionsTab = ({
+  entitiesByTag,
   ruleExemptions = {},
   scorecard,
   scores,
@@ -84,8 +81,7 @@ export const ScorecardRuleExemptionsTab = ({
             return (
               <React.Fragment key={`RuleExemption-${id}`}>
                 {ruleExemptionById.filter(getIsActive).map(ruleExemption => {
-                  let serviceComponentRef =
-                    scoresMap[ruleExemption.entityId] ?? '';
+                  let entityTag = scoresMap[ruleExemption.entityId] ?? '';
 
                   return (
                     <Tooltip
@@ -122,10 +118,12 @@ export const ScorecardRuleExemptionsTab = ({
                               {rulesMap[ruleExemption.ruleId]}
                             </Typography>{' '}
                             for{' '}
-                            {serviceComponentRef ? (
+                            {entityTag ? (
                               <ScorecardServiceRefLink
                                 scorecardId={scorecard.id}
-                                componentRef={serviceComponentRef}
+                                componentRef={entityComponentRef(
+                                  entitiesByTag[entityTag],
+                                )}
                               >
                                 {ruleExemption.entityName}
                               </ScorecardServiceRefLink>

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardRuleExemptionsTab/ScorecardRuleExemptionsTab.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardRuleExemptionsTab/ScorecardRuleExemptionsTab.tsx
@@ -122,7 +122,8 @@ export const ScorecardRuleExemptionsTab = ({
                               <ScorecardServiceRefLink
                                 scorecardId={scorecard.id}
                                 componentRef={entityComponentRef(
-                                  entitiesByTag[entityTag],
+                                  entitiesByTag,
+                                  entityTag,
                                 )}
                               >
                                 {ruleExemption.entityName}

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardRuleExemptionsTab/ScorecardRuleExemptionsTab.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardRuleExemptionsTab/ScorecardRuleExemptionsTab.tsx
@@ -23,12 +23,11 @@ import { getExpirationText, getIsActive, } from './ScorecardRuleExemptionsTabUti
 import ScorecardRuleExemptionTooltip from './ScorecardRuleExemptionTooltip';
 import { ScorecardServiceRefLink } from '../../../ScorecardServiceRefLink';
 import { isEmpty } from 'lodash';
-import { StringIndexable } from '../../../ReportsPage/HeatmapPage/HeatmapUtils';
 import { HomepageEntity } from '../../../../api/userInsightTypes';
 import { entityComponentRef } from '../../../../utils/ComponentUtils';
 
 interface ScorecardRuleExemptionsTabProps {
-  entitiesByTag: StringIndexable<HomepageEntity>;
+  entitiesByTag: Record<string, HomepageEntity>;
   ruleExemptions: ScorecardRuleExemptionResult['scorecardRuleExemptions'];
   scorecard: Scorecard;
   scores: ScorecardServiceScore[];
@@ -81,7 +80,7 @@ export const ScorecardRuleExemptionsTab = ({
             return (
               <React.Fragment key={`RuleExemption-${id}`}>
                 {ruleExemptionById.filter(getIsActive).map(ruleExemption => {
-                  let entityTag = scoresMap[ruleExemption.entityId] ?? '';
+                  const entityTag = scoresMap[ruleExemption.entityId] ?? '';
 
                   return (
                     <Tooltip

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsScoresTab/ScorecardsScoresTable.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsScoresTab/ScorecardsScoresTable.tsx
@@ -80,7 +80,7 @@ export const ScorecardsScoresTable = ({
           <Box>
             <ScorecardServiceRefLink
               scorecardId={scorecardId}
-              componentRef={entityComponentRef(entitiesByTag[tag])}
+              componentRef={entityComponentRef(entitiesByTag, tag)}
             >
               {name}
             </ScorecardServiceRefLink>

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsScoresTab/ScorecardsScoresTable.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsScoresTab/ScorecardsScoresTable.tsx
@@ -14,32 +14,17 @@
  * limitations under the License.
  */
 import React, { useMemo } from 'react';
-import {
-  EmptyState,
-  InfoCard,
-  Table as BSTable,
-  TableColumn,
-} from '@backstage/core-components';
-import {
-  CategoryFilter,
-  ScorecardLadder,
-  ScorecardServiceScore,
-} from '../../../../api/types';
+import { EmptyState, InfoCard, Table as BSTable, TableColumn, } from '@backstage/core-components';
+import { CategoryFilter, ScorecardLadder, ScorecardServiceScore, } from '../../../../api/types';
 import { useDetailCardStyles } from '../../../../styles/styles';
 import { humanizeAnyEntityRef } from '../../../../utils/types';
-import { defaultComponentRefContext } from '../../../../utils/ComponentUtils';
+import { defaultComponentRefContext, entityComponentRef, } from '../../../../utils/ComponentUtils';
 import { ScorecardServiceRefLink } from '../../../ScorecardServiceRefLink';
 import { StringIndexable } from '../../../ReportsPage/HeatmapPage/HeatmapUtils';
 import { HomepageEntity } from '../../../../api/userInsightTypes';
-import { Box, Typography, makeStyles } from '@material-ui/core';
+import { Box, makeStyles, Typography } from '@material-ui/core';
 import { isNil } from 'lodash';
-import {
-  levelSort,
-  scorePercentageSort,
-  levelColumn,
-  scoreColumn,
-  PAGE_SIZE,
-} from './ScorecardsScoresTableConfig';
+import { levelColumn, levelSort, PAGE_SIZE, scoreColumn, scorePercentageSort, } from './ScorecardsScoresTableConfig';
 
 interface ScorecardsScoresTableProps {
   category: CategoryFilter;
@@ -95,7 +80,7 @@ export const ScorecardsScoresTable = ({
           <Box>
             <ScorecardServiceRefLink
               scorecardId={scorecardId}
-              componentRef={tag}
+              componentRef={entityComponentRef(entitiesByTag[tag])}
             >
               {name}
             </ScorecardServiceRefLink>

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardsScoresTab/ScorecardsScoresTable.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardsScoresTab/ScorecardsScoresTable.tsx
@@ -117,7 +117,7 @@ export const ScorecardsScoresTable = ({
         ),
       },
     ],
-    [category, scorecardId, scorecardsTableCardClasses.tag],
+    [category, scorecardId, scorecardsTableCardClasses.tag, entitiesByTag],
   );
 
   const data = useMemo(() => {

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServicePage.tsx
@@ -48,12 +48,15 @@ export const ScorecardsServicePage = () => {
     const ladders = await cortexApi.getScorecardLadders(+scorecardId);
     const scorecard = await cortexApi.getScorecard(+scorecardId);
 
-    const score = allScores.find(serviceScore =>
-      entityEquals(serviceScore.componentRef, entityRef),
+    const score = allScores.find(entityScore =>
+      entityEquals(
+        entitiesByTag[entityScore.componentRef].definition,
+        entityRef,
+      ),
     );
 
     return { allScores, score, scorecard, ladders };
-  }, []);
+  }, [entitiesByTag]);
 
   const { allScores, score, ladders, scorecard } = value ?? {
     allScores: [],

--- a/src/utils/ComponentUtils.ts
+++ b/src/utils/ComponentUtils.ts
@@ -16,8 +16,9 @@
 
 import { Entity } from '@backstage/catalog-model';
 import { CustomMapping } from '@cortexapps/backstage-plugin-extensions';
-import { merge } from 'lodash';
+import { isNil, merge } from 'lodash';
 import { HomepageEntity } from '../api/userInsightTypes';
+import { StringIndexable } from '../components/ReportsPage/HeatmapPage/HeatmapUtils';
 
 export type EntityRefContext = {
   defaultKind?: string;
@@ -57,6 +58,15 @@ export const applyCustomMappings = (
   );
 };
 
-export const entityComponentRef = ({ definition }: HomepageEntity) => {
-  return `${definition.kind}:${definition.namespace}/${definition.name}`;
+export const entityComponentRef = (
+  entitiesByTag: StringIndexable<HomepageEntity>,
+  tag: string,
+) => {
+  const entity = entitiesByTag[tag];
+  if (isNil(entity)) {
+    return tag;
+  }
+  return isNil(entity.definition)
+    ? entity.codeTag
+    : `${entity.definition.kind}:${entity.definition.namespace}/${entity.definition.name}`;
 };

--- a/src/utils/ComponentUtils.ts
+++ b/src/utils/ComponentUtils.ts
@@ -18,7 +18,6 @@ import { Entity } from '@backstage/catalog-model';
 import { CustomMapping } from '@cortexapps/backstage-plugin-extensions';
 import { isNil, merge } from 'lodash';
 import { HomepageEntity } from '../api/userInsightTypes';
-import { StringIndexable } from '../components/ReportsPage/HeatmapPage/HeatmapUtils';
 
 export type EntityRefContext = {
   defaultKind?: string;
@@ -59,7 +58,7 @@ export const applyCustomMappings = (
 };
 
 export const entityComponentRef = (
-  entitiesByTag: StringIndexable<HomepageEntity>,
+  entitiesByTag: Record<string, HomepageEntity>,
   tag: string,
 ) => {
   const entity = entitiesByTag[tag];

--- a/src/utils/ComponentUtils.ts
+++ b/src/utils/ComponentUtils.ts
@@ -17,6 +17,7 @@
 import { Entity } from '@backstage/catalog-model';
 import { CustomMapping } from '@cortexapps/backstage-plugin-extensions';
 import { merge } from 'lodash';
+import { HomepageEntity } from '../api/userInsightTypes';
 
 export type EntityRefContext = {
   defaultKind?: string;
@@ -54,4 +55,8 @@ export const applyCustomMappings = (
     },
     entity,
   );
+};
+
+export const entityComponentRef = ({ definition }: HomepageEntity) => {
+  return `${definition.kind}:${definition.namespace}/${definition.name}`;
 };

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -13,38 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, {
-  DependencyList,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
-import {
-  AnyEntityRef,
-  entityEquals,
-  nullsToUndefined,
-  Predicate,
-  stringifyAnyEntityRef,
-} from './types';
+import React, { DependencyList, useCallback, useEffect, useMemo, useState, } from 'react';
+import { AnyEntityRef, entityEquals, nullsToUndefined, Predicate, stringifyAnyEntityRef, } from './types';
 import { useAsync } from 'react-use';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import {
-  catalogApiRef,
-  getEntityRelations,
-  humanizeEntityRef,
-} from '@backstage/plugin-catalog-react';
+import { catalogApiRef, getEntityRelations, humanizeEntityRef, } from '@backstage/plugin-catalog-react';
 import { groupByString, mapByString, mapValues } from './collections';
-import {
-  Entity,
-  parseEntityRef,
-  RELATION_OWNED_BY,
-  RELATION_PART_OF,
-} from '@backstage/catalog-model';
-import {
-  defaultGroupRefContext,
-  defaultSystemRefContext,
-} from './ComponentUtils';
+import { Entity, parseEntityRef, RELATION_OWNED_BY, RELATION_PART_OF, } from '@backstage/catalog-model';
+import { defaultGroupRefContext, defaultSystemRefContext, } from './ComponentUtils';
 import { cortexApiRef } from '../api';
 import { CortexApi } from '../api/CortexApi';
 import { EntityFilterGroup } from '../filters';


### PR DESCRIPTION
## Change description

Requires https://github.com/cortexapps/brain-backend/pull/5313


1. Use correct `kind` and `namespace` when building Backstage Entity Refs.
2. Use full Entity Ref instead only our `codeTag` to properly identify entity and link within Backstage

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [x] The changelog has been updated as appropriate
- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
