### PR TITLE
[CET-7395] Show rule result error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.6.3
+
+- Fixes issue where rule evaluation error was not displayed
+
 ### 2.6.2
 
 - Fixes issue where resolve hint was displayed for passing rule

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceRuleRow.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceRuleRow.tsx
@@ -119,6 +119,11 @@ export const ScorecardServiceRuleRow = ({
           </Typography>
           <Collapse in={open} timeout="auto" unmountOnExit>
             <>
+              {rule.error && (
+                <Typography color="error" className={classes.ruleQuery}>
+                  {rule.error}
+                </Typography>
+              )}
               {isFailing && rule.failureMessage && (
                 <MarkdownContent
                   className={classes.ruleDescription}

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceRulesDetails.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceRulesDetails.tsx
@@ -61,6 +61,7 @@ export const ScorecardsServiceRulesDetails = ({
               rule={{
                 ...failingRule.rule,
                 score: failingRule.score,
+                error: failingRule.error,
               }}
               hideWeight={hideWeights}
             />

--- a/src/utils/ScorecardRules.ts
+++ b/src/utils/ScorecardRules.ts
@@ -36,6 +36,7 @@ export interface RuleDetail {
   score?: number;
   title?: string;
   weight?: number;
+  error?: string;
 }
 
 export const isApplicableRuleOutcome = (


### PR DESCRIPTION
## Change description

TODO: bump version before merge

[[CET-7395](https://cortex1.atlassian.net/browse/CET-7395)] [GetYourGuide] Backstage plugin - Scorecard rule evaluation failure errors not rendering in Backstage

Before
![image](https://github.com/cortexapps/backstage-plugin/assets/32833929/1a6aa8c0-0987-4147-8ba3-a57ab0715f5f)

After
![image](https://github.com/cortexapps/backstage-plugin/assets/32833929/3b54256f-5ec8-472e-8e63-42f766c64868)

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [x] The changelog has been updated as appropriate
- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[CET-7395]: https://cortex1.atlassian.net/browse/CET-7395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ