### PR TITLE
[CET-7368] Hide the failing message if rule is passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.6.2
+
+- Fixes issue where resolve hint was displayed for passing rule
+
 ### 2.6.1
 
 - Reports filters determined from URL are now also persisted in URL after change

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceRuleRow.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceRuleRow.tsx
@@ -119,7 +119,7 @@ export const ScorecardServiceRuleRow = ({
           </Typography>
           <Collapse in={open} timeout="auto" unmountOnExit>
             <>
-              {rule.failureMessage && (
+              {isFailing && rule.failureMessage && (
                 <MarkdownContent
                   className={classes.ruleDescription}
                   content={rule.failureMessage}


### PR DESCRIPTION
## Change description

TODO: bump version before merge

[[CET-7368](https://cortex1.atlassian.net/browse/CET-7368)][Getyourguide] Rule violation being generated on on passing scorecard rule

Before
![image](https://github.com/cortexapps/backstage-plugin/assets/32833929/7082cc10-8357-4648-b7dc-348c322dec4c)

After
![image](https://github.com/cortexapps/backstage-plugin/assets/32833929/300fb77f-359f-449b-91fd-5bdffa15039e)

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [x] The changelog has been updated as appropriate
- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[CET-7368]: https://cortex1.atlassian.net/browse/CET-7368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ