### PR TITLE
[CET-8100] [Peloton] Backstage plugin rendering Markdown as plain text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.6.4
+
+- Fixes issue where markdown was rendered as plain text on scorecard service page
+
 ### 2.6.3
 
 - Fixes issue where rule evaluation error was not displayed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2.6.4
 
-- Fixes issue where markdown was rendered as plain text on scorecard service page
+- Fixes issue where markdown was rendered as plain text on Scorecard service page
 
 ### 2.6.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/Common/Truncated.tsx
+++ b/src/components/Common/Truncated.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { useMemo, useState } from "react";
+import { BackstageTheme } from "@backstage/theme";
+import { makeStyles } from "@material-ui/core";
+
+const useStyles = makeStyles<BackstageTheme>(styles => ({
+  linkButton: {
+    backgroundColor: 'transparent',
+    border: 'none',
+    color: styles.palette.primary.main,
+    cursor: 'pointer',
+    fontSize: styles.typography.body2.fontSize,
+    padding: 0,
+  },
+}));
+
+interface TruncatedProps {
+  text: string;
+  truncateToLines: number;
+  renderText?: (text: string) => React.ReactElement
+}
+
+export const Truncated: React.FC<TruncatedProps> = ({ text, truncateToLines, renderText }) => {
+  const classes = useStyles();
+
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const allEndOfLines = useMemo(() => {
+    return [...text.matchAll(/\r\n|\r|\n/g)].map(a => a.index);
+  }, [text]);
+
+  const displayedText = useMemo(() => {
+    if (isExpanded || allEndOfLines.length < truncateToLines) {
+      return text;
+    }
+
+    return text.substring(0, allEndOfLines[truncateToLines]) + '...';
+  },  [text, truncateToLines, isExpanded, allEndOfLines]);
+
+  return (
+    <>
+      {renderText ? renderText(displayedText) : displayedText}
+      {allEndOfLines.length > truncateToLines && (
+        <button
+          className={classes.linkButton}
+          onClick={() => setIsExpanded(!isExpanded)}
+        >
+          {isExpanded ? 'Less' : 'More'}
+        </button>
+      )}
+    </>
+  );
+}

--- a/src/components/Common/Truncated.tsx
+++ b/src/components/Common/Truncated.tsx
@@ -29,18 +29,18 @@ const useStyles = makeStyles<BackstageTheme>(styles => ({
 }));
 
 interface TruncatedProps {
-  text: string;
+  text?: string;
   truncateToLines: number;
   renderText?: (text: string) => React.ReactElement
 }
 
-export const Truncated: React.FC<TruncatedProps> = ({ text, truncateToLines, renderText }) => {
+export const Truncated: React.FC<TruncatedProps> = ({ text = '', truncateToLines, renderText }) => {
   const classes = useStyles();
 
   const [isExpanded, setIsExpanded] = useState(false);
 
   const allEndOfLines = useMemo(() => {
-    return [...text.matchAll(/\r\n|\r|\n/g)].map(a => a.index);
+    return Array.from(text.matchAll(/\r\n|\r|\n/g)).map(a => a.index);
   }, [text]);
 
   const displayedText = useMemo(() => {

--- a/src/components/ListCard/ListCard.tsx
+++ b/src/components/ListCard/ListCard.tsx
@@ -13,38 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useMemo, useState } from 'react';
+import React from 'react';
 import {
   Card,
   CardActions,
   CardContent,
   CardMedia,
   Chip,
-  makeStyles,
 } from '@material-ui/core';
 import {
   Button,
   ItemCardHeader,
   MarkdownContent,
 } from '@backstage/core-components';
-import { BackstageTheme } from '@backstage/theme';
-
-const useStyles = makeStyles<BackstageTheme>(styles => ({
-  linkButton: {
-    backgroundColor: 'transparent',
-    border: 'none',
-    color: styles.palette.primary.main,
-    cursor: 'pointer',
-    fontSize: styles.typography.body2.fontSize,
-    padding: 0,
-  },
-}));
+import { Truncated } from '../Common/Truncated';
 
 interface ListCardProps {
   badges?: string[];
   description?: string;
   name: string;
-  truncateToCharacters?: number;
+  truncateToLines?: number;
   url: string;
 }
 
@@ -52,24 +40,9 @@ export const ListCard = ({
   badges,
   description,
   name,
-  truncateToCharacters,
+  truncateToLines,
   url,
 }: ListCardProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const classes = useStyles();
-
-  const descriptionToShow = useMemo(() => {
-    if (!description) {
-      return '';
-    }
-
-    if (truncateToCharacters && !isExpanded) {
-      return description.substring(0, truncateToCharacters) + '...';
-    }
-
-    return description;
-  }, [description, isExpanded, truncateToCharacters]);
-
   return (
     <Card>
       <CardMedia>
@@ -78,14 +51,14 @@ export const ListCard = ({
       <CardContent>
         {description && (
           <>
-            <MarkdownContent content={descriptionToShow ?? ''} />
-            {truncateToCharacters && description.length > truncateToCharacters && (
-              <button
-                className={classes.linkButton}
-                onClick={() => setIsExpanded(!isExpanded)}
-              >
-                {isExpanded ? 'Less' : 'More'}
-              </button>
+            {truncateToLines ? (
+              <Truncated
+                text={description}
+                truncateToLines={truncateToLines}
+                renderText={(text) => <MarkdownContent content={text}/>}
+              />
+            ) : (
+              <MarkdownContent content={description}/>
             )}
           </>
         )}

--- a/src/components/Scorecards/ScorecardCard/ScorecardCard.tsx
+++ b/src/components/Scorecards/ScorecardCard/ScorecardCard.tsx
@@ -35,7 +35,7 @@ export const ScorecardCard = ({ scorecard }: ScorecardCardProps) => {
       badges={customCardDisplayOptions?.getBadgesFn?.(scorecard)}
       description={scorecard.description}
       name={scorecard.name}
-      truncateToCharacters={200}
+      truncateToLines={10}
       url={scorecardRef({ id: `${scorecard.id}` })}
     />
   );

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardMetadataCard/ScorecardMetadataCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardMetadataCard/ScorecardMetadataCard.tsx
@@ -71,7 +71,7 @@ export const ScorecardMetadataCard = ({
           <Box mb={2} className={classes.markdownBox}>
             <CaptionTypography variant="caption">Description</CaptionTypography>
             <Truncated
-              text={scorecard.description || ''}
+              text={scorecard.description}
               truncateToLines={10}
               renderText={(text) => (<MarkdownContent content={text}/>)}
             />

--- a/src/components/Scorecards/ScorecardDetailsPage/ScorecardMetadataCard/ScorecardMetadataCard.tsx
+++ b/src/components/Scorecards/ScorecardDetailsPage/ScorecardMetadataCard/ScorecardMetadataCard.tsx
@@ -22,6 +22,7 @@ import { CortexInfoCard } from '../../../Common/CortexInfoCard';
 import { HoverTimestamp } from '../../../Common/HoverTimestamp';
 import ScorecardMetadataFilter from './ScorecardMetadataFilter';
 import { CaptionTypography } from '../../../Common/StatsItem';
+import { Truncated } from '../../../Common/Truncated';
 
 interface ScorecardMetadataCardProps {
   scorecard: Scorecard;
@@ -69,7 +70,11 @@ export const ScorecardMetadataCard = ({
         {scorecard.description && (
           <Box mb={2} className={classes.markdownBox}>
             <CaptionTypography variant="caption">Description</CaptionTypography>
-            <MarkdownContent content={scorecard.description} />
+            <Truncated
+              text={scorecard.description || ''}
+              truncateToLines={10}
+              renderText={(text) => (<MarkdownContent content={text}/>)}
+            />
           </Box>
         )}
         <Box mb={2}>

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceHeader.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceHeader.tsx
@@ -89,7 +89,7 @@ export const ScorecardServiceHeader = ({
           {scorecard.description && (
             <Box mb={1}>
             <Truncated
-              text={scorecard.description || ''}
+              text={scorecard.description}
               truncateToLines={10}
               renderText={(text) => (<MarkdownContent content={text}/>)}
             />

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceHeader.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceHeader.tsx
@@ -15,7 +15,7 @@
  */
 import React, { useMemo } from 'react';
 import { useRouteRef, useRouteRefParams } from '@backstage/core-plugin-api';
-import { Link } from '@backstage/core-components';
+import { Link, MarkdownContent } from '@backstage/core-components';
 import { Typography } from '@material-ui/core';
 import {
   scorecardRouteRef,
@@ -87,7 +87,7 @@ export const ScorecardServiceHeader = ({
           </Box>
           {scorecard.description && (
             <Box mb={1}>
-              <Typography>{scorecard.description}</Typography>
+              <MarkdownContent content={scorecard.description} />
             </Box>
           )}
           {lastEvaluation && (

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceHeader.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceHeader.tsx
@@ -32,6 +32,7 @@ import moment from 'moment';
 import { HoverTimestamp } from '../../Common/HoverTimestamp';
 import { StringIndexable } from '../../ReportsPage/HeatmapPage/HeatmapUtils';
 import { HomepageEntity } from '../../../api/userInsightTypes';
+import { Truncated } from '../../Common/Truncated';
 
 interface ScorecardServiceHeaderProps {
   entitiesByTag: StringIndexable<HomepageEntity>;
@@ -87,7 +88,11 @@ export const ScorecardServiceHeader = ({
           </Box>
           {scorecard.description && (
             <Box mb={1}>
-              <MarkdownContent content={scorecard.description} />
+            <Truncated
+              text={scorecard.description || ''}
+              truncateToLines={10}
+              renderText={(text) => (<MarkdownContent content={text}/>)}
+            />
             </Box>
           )}
           {lastEvaluation && (


### PR DESCRIPTION
## Change description

[[CET-8100](https://cortex1.atlassian.net/browse/CET-8100)] [Peloton] Backstage plugin rendering Markdown as plain text

As a part of the feature, I created new component `Truncated` to wrap and truncate text by the number of lines.

## Screenshots

Before:
![image](https://github.com/cortexapps/backstage-plugin/assets/32833929/5d9b794a-a5c4-4d7c-9e47-4421ba2cbe04)

After:
![image](https://github.com/cortexapps/backstage-plugin/assets/32833929/61159cf1-dce7-41a6-b417-efa35728fc19)

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [x] The changelog has been updated as appropriate
- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[CET-8100]: https://cortex1.atlassian.net/browse/CET-8100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ