### PR TITLE
Prevent expiration banner from appearing prior to 90 days of trail expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.6.5
+
+- Fixes issue with expiration banner appearing when more than 90 days are left on trail accounts.
+
 ### 2.6.4
 
 - Fixes issue where markdown was rendered as plain text on Scorecard service page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/Entitlements/ExpirationBanner.tsx
+++ b/src/components/Entitlements/ExpirationBanner.tsx
@@ -29,6 +29,11 @@ export const ExpirationBanner = ({ contractType, expirationDate, shutdownDate }:
     return null;
   }
 
+  // Don't show the banner if the expiration date is more than 90 days away
+  if (daysUntilExpiration > 90) {
+    return null;
+  }
+
   const daysUntilShutdown = daysUntil(shutdownDate);
   const isTrial = contractType === 'TRIAL';
   const isExpired = daysUntilExpiration < 0;


### PR DESCRIPTION
## Change description

Only show banner within 3 months of expiration date.

## Type of change

- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [X] The changelog has been updated as appropriate
- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines
