### PR TITLE
CET-8301 Update backstage after initiative filter changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,19 @@
 
 ### 2.6.5
 
-- Fixes issue where groups filters were not rendered correctly in metadata on Initiative page
+- Fix issue where groups filters are not rendered correctly in metadata on Initiative page
 
 ### 2.6.4
 
-- Fixes issue where markdown was rendered as plain text on Scorecard service page
+- Fix issue where markdown is rendered as plain text on Scorecard service page
 
 ### 2.6.3
 
-- Fixes issue where rule evaluation error was not displayed
+- Fix issue where rule evaluation error is not displayed
 
 ### 2.6.2
 
-- Fixes issue where resolve hint was displayed for passing rule
+- Fix issue where resolve hint is displayed for passing rule
 
 ### 2.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.6.5
+
+- Fixes issue where groups filters were not rendered correctly in metadata on Initiative page
+
 ### 2.6.4
 
 - Fixes issue where markdown was rendered as plain text on Scorecard service page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -316,7 +316,7 @@ export interface CatalogEntityMetadata extends EntityMetadata {
 
 export interface Initiative {
   description?: string;
-  entityGroups: ServiceGroup[];
+  filter?: EntityFilter | CompoundFilter | null;
   id: string;
   levels: InitiativeLadderLevel[];
   name: string;
@@ -484,7 +484,7 @@ export interface TeamFilter {
 }
 
 // TODO(catalog-customization): merge GenericCqlFilter and CqlFilter, when we can fully support the "Generic" category app wide.
-export interface GenericCqlFilter extends Omit<CqlFilter, "category"> {
+export interface GenericCqlFilter extends Omit<CqlFilter, 'category'> {
   category: 'Generic';
 }
 

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.test.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.test.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2023 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { TestApiProvider, wrapInTestApp } from '@backstage/test-utils';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { cortexApiRef } from '../../../api';
+import { CortexApi } from '../../../api/CortexApi';
+import { extensionApiRef } from '../../../api/ExtensionApi';
+import { rootRouteRef } from '../../../routes';
+import { Fixtures } from '../../../utils/TestUtils';
+import { InitiativeDetailsPage } from './InitiativeDetailsPage';
+import { CompoundFilter, FilterType, Initiative } from '../../../api/types';
+
+type AnyFunction = (args?: [] | [any]) => any;
+type ApiOverrides = Record<string, AnyFunction>;
+
+describe('Initiative Details Page', () => {
+  const getCortexApi = (overrides?: ApiOverrides): Partial<CortexApi> => ({
+    getInitiative: async () => Fixtures.initiativeWithScores(),
+    getInitiativeActionItems: async () => [],
+    ...overrides,
+  });
+
+  const renderInitiativeDetailsPage = (overrides?: ApiOverrides) =>
+    render(
+      wrapInTestApp(
+        <TestApiProvider
+          apis={[
+            [cortexApiRef, getCortexApi(overrides)],
+            [catalogApiRef, {}],
+            [extensionApiRef, {}],
+          ]}
+        >
+          <InitiativeDetailsPage />
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/': rootRouteRef as any,
+          },
+        },
+      ),
+    );
+
+  it('should render', async () => {
+    // GIVEN
+    const name = 'Test Initiative Name';
+    // WHEN
+    const { findByText } = renderInitiativeDetailsPage({
+      getInitiative: async () =>
+        Fixtures.initiativeWithScores({
+          name,
+          targetDate: '2026-06-06T06:00:00',
+        }),
+    });
+    // THEN
+    expect(await findByText(name)).toBeVisible();
+    expect(await findByText(/Due by June 6th, 2026/)).toBeVisible();
+  });
+
+  describe('group filter text in metadata', () => {
+    const renderWithFilter = (filter: Initiative['filter']) => {
+      return renderInitiativeDetailsPage({
+        getInitiative: async () => Fixtures.initiativeWithScores({ filter }),
+      });
+    };
+
+    it('should handle no filter', async () => {
+      // GIVEN
+      const filter = undefined;
+      // WHEN
+      const { findByText } = renderWithFilter(filter);
+      // THEN
+      expect(await findByText(/Applies to all services/)).toBeVisible();
+    });
+
+    it('should handle single group', async () => {
+      // GIVEN
+      const filter: CompoundFilter = {
+        entityGroupFilter: {
+          entityGroups: ['test:group'],
+          excludedEntityGroups: [],
+        },
+        type: FilterType.COMPOUND_FILTER,
+      };
+      // WHEN
+      const { findByText } = renderWithFilter(filter);
+      // THEN
+      expect(
+        await findByText(/Applies to services in group test:group/),
+      ).toBeVisible();
+    });
+
+    it('should handle two groups', async () => {
+      // GIVEN
+      const filter: CompoundFilter = {
+        entityGroupFilter: {
+          entityGroups: ['test:group:1', 'test:group:2'],
+          excludedEntityGroups: [],
+        },
+        type: FilterType.COMPOUND_FILTER,
+      };
+      // WHEN
+      const { findByText } = renderWithFilter(filter);
+      // THEN
+      expect(
+        await findByText(
+          /Applies to services in groups test:group:1 and test:group:2/,
+        ),
+      ).toBeVisible();
+    });
+
+    it('should handle three groups', async () => {
+      // GIVEN
+      const filter: CompoundFilter = {
+        entityGroupFilter: {
+          entityGroups: ['test:group:1', 'test:group:2', 'test:group:3'],
+          excludedEntityGroups: [],
+        },
+        type: FilterType.COMPOUND_FILTER,
+      };
+      // WHEN
+      const { findByText } = renderWithFilter(filter);
+      // THEN
+      expect(
+        await findByText(
+          /Applies to services in groups test:group:1, test:group:2, and test:group:3/,
+        ),
+      ).toBeVisible();
+    });
+
+    it('should handle excluded groups', async () => {
+      // GIVEN
+      const filter: CompoundFilter = {
+        entityGroupFilter: {
+          entityGroups: [],
+          excludedEntityGroups: ['test:group:1'],
+        },
+        type: FilterType.COMPOUND_FILTER,
+      };
+      // WHEN
+      const { findByText } = renderWithFilter(filter);
+      // THEN
+      expect(
+        await findByText(
+          /Applies to services in all groups, excluding test:group:1/,
+        ),
+      ).toBeVisible();
+    });
+  });
+});

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeMetadataCard/InitiativeMetadataFilter.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeMetadataCard/InitiativeMetadataFilter.tsx
@@ -46,11 +46,13 @@ const InitiativeMetadataFilter: React.FC<InitiativeMetadataFilterProps> = ({
   return (
     <Typography variant="body2">
       Applies to {!hasIncludes && !hasExcludes ? 'all' : ''}{' '}
-      {entityCategory?.toLowerCase() || 'entitie'}s{' '}
+      {entityCategory?.toLowerCase() || 'entitie'}s
       {(hasIncludes || hasExcludes) && (
         <>
-          in {!hasIncludes && ' all '} groups{' '}
-          {hasIncludes && joinWithAnds(entityGroups)}
+          {' '}
+          in {!hasIncludes && ' all '} group
+          {!hasIncludes || entityGroups.length > 1 ? 's' : ''}
+          {hasIncludes && <> {joinWithAnds(entityGroups)}</>}
           {hasExcludes && <>, excluding {joinWithAnds(excludeEntityGroups)}</>}
         </>
       )}

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeMetadataCard/InitiativeMetadataFilter.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeMetadataCard/InitiativeMetadataFilter.tsx
@@ -17,7 +17,10 @@ import React, { useMemo } from 'react';
 import { Initiative } from '../../../../api/types';
 import { Typography } from '@material-ui/core';
 import { isEmpty } from 'lodash';
-import { getEntityCategoryFromFilter } from '../../../Scorecards/ScorecardDetailsPage/ScorecardMetadataCard/ScorecardMetadataUtils';
+import {
+  getEntityCategoryFromFilter,
+  getEntityGroupsFromFilter,
+} from '../../../Scorecards/ScorecardDetailsPage/ScorecardMetadataCard/ScorecardMetadataUtils';
 import { joinWithAnds } from '../../../../utils/strings';
 
 interface InitiativeMetadataFilterProps {
@@ -32,14 +35,25 @@ const InitiativeMetadataFilter: React.FC<InitiativeMetadataFilterProps> = ({
     [initiative],
   );
 
-  const groups = useMemo(() => {
-    return initiative.entityGroups.map(group => group.tag);
-  }, [initiative]);
+  const { entityGroups, excludeEntityGroups } = useMemo(
+    () => getEntityGroupsFromFilter(initiative.filter),
+    [initiative.filter],
+  );
+
+  const hasIncludes = !isEmpty(entityGroups);
+  const hasExcludes = !isEmpty(excludeEntityGroups);
 
   return (
     <Typography variant="body2">
-      Applies to {isEmpty(groups) ? 'all' : joinWithAnds(groups)}{' '}
-      {entityCategory?.toLowerCase() || 'entitie'}s
+      Applies to {!hasIncludes && !hasExcludes ? 'all' : ''}{' '}
+      {entityCategory?.toLowerCase() || 'entitie'}s{' '}
+      {(hasIncludes || hasExcludes) && (
+        <>
+          in {!hasIncludes && ' all '} groups{' '}
+          {hasIncludes && joinWithAnds(entityGroups)}
+          {hasExcludes && <>, excluding {joinWithAnds(excludeEntityGroups)}</>}
+        </>
+      )}
     </Typography>
   );
 };

--- a/src/components/Initiatives/InitiativesPage/InitiativesList.tsx
+++ b/src/components/Initiatives/InitiativesPage/InitiativesList.tsx
@@ -37,7 +37,6 @@ import { isEmpty, isNil, isUndefined } from 'lodash';
 import { useDropdown, useInput } from '../../../utils/hooks';
 import { hasText } from '../../../utils/SearchUtils';
 import { Initiative } from '../../../api/types';
-import { hasTags } from '../../Scorecards/ScorecardsPage/ScorecardList';
 import { SortDropdown, SortMethods } from '../../Common/SortDropdown';
 import moment from 'moment';
 
@@ -74,8 +73,7 @@ export const InitiativesList = () => {
         hasText(initiative, 'name', searchQuery) ||
         hasText(initiative, 'description', searchQuery) ||
         hasText(initiative, 'scorecard.name', searchQuery) ||
-        hasText(initiative, 'scorecard.description', searchQuery) ||
-        hasTags(initiative.entityGroups, searchQuery)
+        hasText(initiative, 'scorecard.description', searchQuery)
       );
     });
 

--- a/src/utils/TestUtils.tsx
+++ b/src/utils/TestUtils.tsx
@@ -29,6 +29,8 @@ import { CortexApi } from '../api/CortexApi';
 import { ExternalRouteRef, RouteRef } from '@backstage/core-plugin-api';
 import {
   FilterType,
+  Initiative,
+  InitiativeWithScores,
   Scorecard,
   ScorecardLevel,
   ScorecardServiceScore,
@@ -236,4 +238,28 @@ export class Fixtures {
         ...partial,
       };
     };
+
+  static initiative: (partial?: Partial<Initiative>) => Initiative =
+    partial => {
+      return {
+        entityGroups: [],
+        levels: [],
+        description: 'Some description',
+        id: '1',
+        name: 'My Initiative',
+        rules: [],
+        scorecard: Fixtures.scorecard(),
+        targetDate: '2025-01-01T08:00:00',
+        ...partial,
+      };
+    };
+
+  static initiativeWithScores: (
+    partial?: Partial<InitiativeWithScores>,
+  ) => InitiativeWithScores = partial => {
+    return {
+      scores: [],
+      ...Fixtures.initiative(partial),
+    };
+  };
 }


### PR DESCRIPTION
## Change description

https://cortex1.atlassian.net/browse/CET-8301

Entity groups for initiatives are sent by brain-backend the same way as they are for scorecards, so I removed the unused attribute (entityGroups) from the model and added the new one (filter), then reused some logic from scorecards utils to print a correct text.

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [x] The changelog has been updated as appropriate
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
