### PR TITLE
CET-8544 Swap rule description and rule query text colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.6.6
+
+- Fix rule description and rule query text colors
+
 ### 2.6.5
 
 - Fix issue where groups filters are not rendered correctly in metadata on Initiative page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceRuleRow.tsx
+++ b/src/components/Scorecards/ScorecardsServicePage/ScorecardsServiceRuleRow.tsx
@@ -48,12 +48,12 @@ const useStyles = makeStyles(theme => ({
   },
   ruleDescription: {
     margin: theme.spacing(1, 0),
-    color: fallbackPalette.common.gray,
     '& p': {
       margin: 0,
     },
   },
   ruleQuery: {
+    color: fallbackPalette.common.gray,
     fontFamily: 'Monospace',
     fontSize: 12,
   },


### PR DESCRIPTION
## Change description
https://cortex1.atlassian.net/browse/CET-8544
Text colors of rule description and rule query are swapped what makes the rule more readable.
![image](https://github.com/cortexapps/backstage-plugin/assets/14073689/4e40f608-f3c1-4013-bd5b-d79c373223c2)

## Type of change

- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [X] The changelog has been updated as appropriate
- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
