### PR TITLE
Add in entity click logic when in hierarchy mode

### DIFF
--- a/src/components/ReportsPage/HeatmapPage/HeatmapUtils.ts
+++ b/src/components/ReportsPage/HeatmapPage/HeatmapUtils.ts
@@ -139,8 +139,7 @@ export const getScorecardServiceScoresByGroupByOption = (
   }
 };
 
-
-interface HierarchyNode {
+export interface HierarchyNode {
   node: {
     tag: string;
   }

--- a/src/components/ReportsPage/HeatmapPage/HeatmapUtils.ts
+++ b/src/components/ReportsPage/HeatmapPage/HeatmapUtils.ts
@@ -151,7 +151,7 @@ export const hierarchyNodeFlatChildren = (node: HierarchyNode): string[] => {
   return node.orderedChildren.flatMap((child) => [child.node.tag, ...hierarchyNodeFlatChildren(child)]);
 }
 
-export const groupScoresByHierarchies = (groupedScores: StringIndexable<ScorecardServiceScore[]>, nodes: HierarchyNode[]) => {
+export const groupScoresByHierarchies = (groupedScores: StringIndexable<ScorecardServiceScore[]>, nodes: HierarchyNode[], currentHierarchyItemTag?: string) => {
   const hierarchyGroupedData = {} as Record<string, ScorecardServiceScore[]>;
 
   nodes.forEach((parent) => {
@@ -165,6 +165,10 @@ export const groupScoresByHierarchies = (groupedScores: StringIndexable<Scorecar
       });
     });
   });
+
+  if (currentHierarchyItemTag && groupedScores[currentHierarchyItemTag]?.length) {
+    hierarchyGroupedData[currentHierarchyItemTag] = groupedScores[currentHierarchyItemTag];
+  }
 
   return hierarchyGroupedData;
 }

--- a/src/components/ReportsPage/HeatmapPage/Tables/HeatmapTableByGroup.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/HeatmapTableByGroup.tsx
@@ -32,6 +32,7 @@ interface HeatmapTableByGroupProps {
   hideWithoutChildren?: boolean;
   onSelect: (identifier: string) => void;
   useHierarchy: boolean;
+  lastPathItem?: string;
 }
 
 export const HeatmapTableByGroup = ({
@@ -42,6 +43,7 @@ export const HeatmapTableByGroup = ({
   hideWithoutChildren = false,
   onSelect,
   useHierarchy,
+  lastPathItem,
 }: HeatmapTableByGroupProps) => {
   const headers = [
     header,
@@ -54,7 +56,7 @@ export const HeatmapTableByGroup = ({
     <Table>
       <HeatmapTableHeader headers={headers} />
       <TableBody>
-        {Object.entries(data).map(([identifier, values]) => {
+        {Object.entries(data).map(([identifier, values = []]) => {
           const serviceCount = values.length;
 
           if (serviceCount < 1 && hideWithoutChildren) {
@@ -77,8 +79,9 @@ export const HeatmapTableByGroup = ({
                     onClick={() => {
                       onSelect(identifier);
                     }}
+                    style={{ width: '100%' }}
                   >
-                    {identifier}
+                    {identifier === lastPathItem ? `Everything owned by ${lastPathItem}` : identifier}
                   </Link>
                 ) : (
                   <Typography variant={'subtitle1'}>{identifier}</Typography>

--- a/src/components/ReportsPage/HeatmapPage/Tables/LevelsDrivenTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/LevelsDrivenTable.tsx
@@ -48,6 +48,7 @@ interface LevelsDrivenTableProps {
   onSelect: (identifier: string) => void;
   useHierarchy: boolean;
   hideWithoutChildren: boolean;
+  lastPathItem?: string;
 }
 
 export const LevelsDrivenTable = ({
@@ -59,6 +60,7 @@ export const LevelsDrivenTable = ({
   onSelect,
   useHierarchy,
   hideWithoutChildren,
+  lastPathItem,
 }: LevelsDrivenTableProps) => {
   const notGroupedByServices = groupBy !== GroupByOption.ENTITY;
   const headers = [
@@ -71,7 +73,7 @@ export const LevelsDrivenTable = ({
     <Table>
       <HeatmapTableHeader headers={headers} />
       <TableBody>
-        {Object.entries(data).map(([key, values]) => {
+        {Object.entries(data).map(([key, values = []]) => {
           const serviceCount = values.length;
 
           if (serviceCount < 1 && hideWithoutChildren) {
@@ -90,11 +92,12 @@ export const LevelsDrivenTable = ({
                       component="button"
                       variant="subtitle1"
                       color="primary"
+                      style={{ width: '100%' }}
                       onClick={() => {
                         onSelect(key);
                       }}
                     >
-                      {key}
+                      {key === lastPathItem ? `Everything owned by ${lastPathItem}` : key}
                     </Link>
                   ) : (
                     <Typography

--- a/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
@@ -238,6 +238,9 @@ export const SingleScorecardHeatmapTable = ({
           groupBy: GroupByOption.ENTITY,
           scoreFilters: {
             ...prev.scoreFilters,
+            // reset conflicting filters
+            teams: [],
+            domainIds: [],
             ...selectedFilter,
           },
         };

--- a/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
@@ -174,7 +174,7 @@ export const SingleScorecardHeatmapTable = ({
           }
         }
 
-        return groupScoresByHierarchies(groupedData, items);
+        return groupScoresByHierarchies(groupedData, items, lastPathItem);
       } else if (groupBy === GroupByOption.DOMAIN && domainHierarchies) {
         let items = domainHierarchies.orderedTree;
         let foundHierarchyItem: DomainHierarchyNode | undefined;
@@ -188,7 +188,8 @@ export const SingleScorecardHeatmapTable = ({
             items = foundHierarchyItem.orderedChildren;
           }
         }
-        return groupScoresByHierarchies(groupedData, items);
+
+        return groupScoresByHierarchies(groupedData, items, lastPathItem);
       }
     }
 
@@ -223,7 +224,7 @@ export const SingleScorecardHeatmapTable = ({
 
     // If an empty item is clicked we have no more navigation to do
     // So we should apply our filters and navigate to the entity view
-    if (isEmpty(hierarchyItem?.orderedChildren)) {
+    if (isEmpty(hierarchyItem?.orderedChildren) || identifier === lastPathItem) {
       const selectedFilter =
         groupBy === GroupByOption.DOMAIN
           ? {
@@ -276,6 +277,7 @@ export const SingleScorecardHeatmapTable = ({
           onSelect={onSelect}
           useHierarchy={useHierarchy}
           hideWithoutChildren={hideWithoutChildren}
+          lastPathItem={lastPathItem}
         />
       );
     }
@@ -313,6 +315,7 @@ export const SingleScorecardHeatmapTable = ({
           hideWithoutChildren={hideWithoutChildren}
           onSelect={onSelect}
           useHierarchy={useHierarchy}
+          lastPathItem={lastPathItem}
         />
       );
     case GroupByOption.LEVEL:
@@ -334,6 +337,7 @@ export const SingleScorecardHeatmapTable = ({
           hideWithoutChildren={hideWithoutChildren}
           onSelect={onSelect}
           useHierarchy={useHierarchy}
+          lastPathItem={lastPathItem}
         />
       );
   }


### PR DESCRIPTION
## Change description

If we detect that the next click is the end of the line in regards to hierarchy then we apply a filter and group by entity so that we can view the list of entities for that item.

I think this can then be used for the same logic of "Everything owned by X".

## Type of change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [x] The changelog has been updated as appropriate
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
