### PR TITLE
Show `No Level` and so we can see the services associated

### DIFF
--- a/src/components/ReportsPage/HeatmapPage/HeatmapUtils.ts
+++ b/src/components/ReportsPage/HeatmapPage/HeatmapUtils.ts
@@ -22,7 +22,14 @@ import {
   RuleOutcome,
   ScorecardScoreNextSteps,
 } from '../../../api/types';
-import { groupBy as _groupBy, flatten as _flatten, values, uniq, intersection, isEmpty } from 'lodash';
+import {
+  groupBy as _groupBy,
+  flatten as _flatten,
+  values,
+  uniq,
+  intersection,
+  isEmpty,
+} from 'lodash';
 import { filterNotUndefined } from '../../../utils/collections';
 import { isApplicableRuleOutcome } from '../../../utils/ScorecardRules';
 import { HomepageEntity } from '../../../api/userInsightTypes';
@@ -76,7 +83,7 @@ const groupByKeyToLabel: Record<GroupByKeys, string> = {
   tags: 'group',
   ladderLevels: 'level',
   domains: 'domain',
-}
+};
 
 const groupReportDataBy = <T extends GroupByValues>(
   scores: T[],
@@ -84,9 +91,10 @@ const groupReportDataBy = <T extends GroupByValues>(
   domainTagByEntityId?: Record<string, string[]>,
 ): StringIndexable<T[]> => {
   return scores.reduce<StringIndexable<T[]>>((data, score) => {
-    const groups = groupBy !== "domains"
-      ? score[groupBy]
-      : domainTagByEntityId?.[score.serviceId] ?? [];
+    const groups =
+      groupBy !== 'domains'
+        ? score[groupBy]
+        : domainTagByEntityId?.[score.serviceId] ?? [];
 
     if (!groups?.length) {
       const key = `No ${groupByKeyToLabel[groupBy]}`;
@@ -139,27 +147,37 @@ export const getScorecardServiceScoresByGroupByOption = (
   }
 };
 
-
 interface HierarchyNode {
   node: {
     tag: string;
-  }
+  };
   orderedChildren: HierarchyNode[];
 }
 
 export const hierarchyNodeFlatChildren = (node: HierarchyNode): string[] => {
-  return node.orderedChildren.flatMap((child) => [child.node.tag, ...hierarchyNodeFlatChildren(child)]);
-}
+  return node.orderedChildren.flatMap(child => [
+    child.node.tag,
+    ...hierarchyNodeFlatChildren(child),
+  ]);
+};
 
-export const groupScoresByHierarchies = (groupedScores: StringIndexable<ScorecardServiceScore[]>, nodes: HierarchyNode[]) => {
+export const groupScoresByHierarchies = (
+  groupedScores: StringIndexable<ScorecardServiceScore[]>,
+  nodes: HierarchyNode[],
+) => {
   const hierarchyGroupedData = {} as Record<string, ScorecardServiceScore[]>;
 
-  nodes.forEach((parent) => {
-    hierarchyGroupedData[parent.node.tag] = groupedScores[parent.node.tag] ?? [];
+  nodes.forEach(parent => {
+    hierarchyGroupedData[parent.node.tag] =
+      groupedScores[parent.node.tag] ?? [];
 
-    hierarchyNodeFlatChildren(parent).forEach((childTag) => {
-      (groupedScores[childTag] ?? []).forEach((score) => {
-        if (!hierarchyGroupedData[parent.node.tag].find((existingScore) => existingScore.componentRef === score.componentRef)) {
+    hierarchyNodeFlatChildren(parent).forEach(childTag => {
+      (groupedScores[childTag] ?? []).forEach(score => {
+        if (
+          !hierarchyGroupedData[parent.node.tag].find(
+            existingScore => existingScore.componentRef === score.componentRef,
+          )
+        ) {
           hierarchyGroupedData[parent.node.tag].push(score);
         }
       });
@@ -167,17 +185,22 @@ export const groupScoresByHierarchies = (groupedScores: StringIndexable<Scorecar
   });
 
   return hierarchyGroupedData;
-}
+};
 
-export const catalogToRelationsByEntityId = (entitiesByTag: StringIndexable<HomepageEntity>) => {
+export const catalogToRelationsByEntityId = (
+  entitiesByTag: StringIndexable<HomepageEntity>,
+) => {
   const ownerEmailByEntityId = {} as Record<string, string[]>;
   const groupTagByEntityId = {} as Record<string, string[]>;
 
-  Object.values(entitiesByTag).forEach((entity) => {
+  Object.values(entitiesByTag).forEach(entity => {
     if (entity.serviceOwnerEmails.length) {
       const ownerEmails = entity.serviceOwnerEmails.map(({ email }) => email);
       if (ownerEmailByEntityId[entity.id]) {
-        ownerEmailByEntityId[entity.id] = uniq([...ownerEmails, ...ownerEmailByEntityId[entity.id]]);
+        ownerEmailByEntityId[entity.id] = uniq([
+          ...ownerEmails,
+          ...ownerEmailByEntityId[entity.id],
+        ]);
       } else {
         ownerEmailByEntityId[entity.id] = ownerEmails;
       }
@@ -185,7 +208,10 @@ export const catalogToRelationsByEntityId = (entitiesByTag: StringIndexable<Home
 
     if (entity.serviceGroupTags) {
       if (groupTagByEntityId[entity.id]) {
-        groupTagByEntityId[entity.id] = uniq([...entity.serviceGroupTags, ...groupTagByEntityId[entity.id]]);
+        groupTagByEntityId[entity.id] = uniq([
+          ...entity.serviceGroupTags,
+          ...groupTagByEntityId[entity.id],
+        ]);
       } else {
         groupTagByEntityId[entity.id] = entity.serviceGroupTags;
       }
@@ -194,9 +220,9 @@ export const catalogToRelationsByEntityId = (entitiesByTag: StringIndexable<Home
 
   return {
     ownerEmailByEntityId,
-    groupTagByEntityId
+    groupTagByEntityId,
   };
-}
+};
 
 export const applyScoreFilters = (
   scores: ScorecardServiceScore[],
@@ -205,17 +231,36 @@ export const applyScoreFilters = (
   groupTagByEntityId: StringIndexable<string[]>,
   domainIdByEntityId: Record<number, number[]>,
 ) => {
-  return scores.filter((score) => {
+  return scores.filter(score => {
     return (
-      (isEmpty(scoreFilters.serviceIds) || scoreFilters.serviceIds.includes(score.serviceId)) &&
-      (isEmpty(scoreFilters.groups) || intersection(scoreFilters.groups, groupTagByEntityId?.[score.serviceId] || []).length) &&
-      (isEmpty(scoreFilters.teams) || intersection(scoreFilters.teams, score.teams || []).length) &&
-      (isEmpty(scoreFilters.users) || intersection(scoreFilters.users, ownerEmailByEntityId?.[score.serviceId] || []).length) &&
-      (isEmpty(scoreFilters.levels) || score.ladderLevels.some((ladderLevel) => scoreFilters.levels.includes(ladderLevel.currentLevel?.name ?? "No Level"))) &&
-      (isEmpty(scoreFilters.domainIds) || intersection(domainIdByEntityId?.[score.serviceId] || [], scoreFilters.domainIds).length)
+      (isEmpty(scoreFilters.serviceIds) ||
+        scoreFilters.serviceIds.includes(score.serviceId)) &&
+      (isEmpty(scoreFilters.groups) ||
+        intersection(
+          scoreFilters.groups,
+          groupTagByEntityId?.[score.serviceId] || [],
+        ).length) &&
+      (isEmpty(scoreFilters.teams) ||
+        intersection(scoreFilters.teams, score.teams || []).length) &&
+      (isEmpty(scoreFilters.users) ||
+        intersection(
+          scoreFilters.users,
+          ownerEmailByEntityId?.[score.serviceId] || [],
+        ).length) &&
+      (isEmpty(scoreFilters.levels) ||
+        score.ladderLevels.some(ladderLevel =>
+          scoreFilters.levels.includes(
+            ladderLevel.currentLevel?.name ?? 'No Level',
+          ),
+        )) &&
+      (isEmpty(scoreFilters.domainIds) ||
+        intersection(
+          domainIdByEntityId?.[score.serviceId] || [],
+          scoreFilters.domainIds,
+        ).length)
     );
   });
-}
+};
 
 interface ScorecardRuleMetadata {
   ruleName: string;

--- a/src/components/ReportsPage/HeatmapPage/LevelsInfoCell.tsx
+++ b/src/components/ReportsPage/HeatmapPage/LevelsInfoCell.tsx
@@ -14,13 +14,23 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Accordion, AccordionDetails, AccordionSummary, makeStyles, TableCell, Typography, } from '@material-ui/core';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  makeStyles,
+  TableCell,
+  Typography,
+} from '@material-ui/core';
 import { ExpandMore } from '@material-ui/icons';
 import { EntityRefLink } from '@backstage/plugin-catalog-react';
 import { parseEntityRef } from '@backstage/catalog-model';
 
 import { maybePluralize } from '../../../utils/strings';
-import { defaultComponentRefContext, entityComponentRef, } from '../../../utils/ComponentUtils';
+import {
+  defaultComponentRefContext,
+  entityComponentRef,
+} from '../../../utils/ComponentUtils';
 
 import { ScorecardServiceScore } from '../../../api/types';
 import { BackstageTheme } from '@backstage/theme';

--- a/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
@@ -238,6 +238,9 @@ export const SingleScorecardHeatmapTable = ({
           groupBy: GroupByOption.ENTITY,
           scoreFilters: {
             ...prev.scoreFilters,
+            // reset conflicting filters
+            teams: [],
+            domainIds: [],
             ...selectedFilter,
           },
         };

--- a/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
@@ -116,7 +116,7 @@ export const SingleScorecardHeatmapTable = ({
   const headers = useMemo(
     () =>
       (!isUndefined(ladder) && levelsDriven
-        ? getSortedLadderLevelNames(ladder)
+        ? getSortedLadderLevelNames(ladder, true)
         : scores[0] && getSortedRuleNames(scores[0])) ?? [],
     [levelsDriven, ladder, scores],
   );


### PR DESCRIPTION
## Change description

Include the `No Levels` column so we display entities dropdown correctly 

Just passed in `true` and the rest was just formatting.

## Type of change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [x] The changelog has been updated as appropriate
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
