### PR TITLE
Fix disabling levels hierarchy breadcrumbs correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.10.2
+
+- Fix disabling levels hierarchy breadcrumbs correctly
+
 ### 2.10.1
 
 - Fix table measure bug for new breadcrumb options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
+++ b/src/components/ReportsPage/HeatmapPage/Tables/SingleScorecardHeatmapTable.tsx
@@ -334,7 +334,7 @@ export const SingleScorecardHeatmapTable = ({
               groupBy={breadcrumbGroupBy}
               onClick={onHierarchyBreadcrumbClick}
               items={resolvedBreadcrumbs}
-              enableLastItem={true}
+              enableLastItem={groupBy === GroupByOption.ENTITY}
             />
           )}
           {!useHierarchy && !!filters.selectedGroupBy && (


### PR DESCRIPTION
## Change description

When in hierarchy mode we should disable the last item as it doesn't need to be clickable. Once we dive into entity view we can enable it.

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [x] The changelog has been updated as appropriate
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
