### PR TITLE
[CET-9710] Initiative due date discrepancy between Cortex and Backstage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.11.3
+
+- Revert converting to local timezone for Initiative target date
+
 ### 2.11.2
 
 - Reset the Initiative filters modal when the modal is closed without applying the filters

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/Homepage/HomepageInsightCard.tsx
+++ b/src/components/Homepage/HomepageInsightCard.tsx
@@ -73,7 +73,7 @@ export const HomepageInsightCard = ({
         <InsightCard>
           You have{' '}
           {maybePluralize(actionItemInsight.ruleIds.length, 'action item')} due
-          by {moment(actionItemInsight.targetDate).local().format('MMM Do')}
+          by {moment.utc(actionItemInsight.targetDate).format('MMM Do')}
           {!isNil(entity) && (
             <>
               {' '}

--- a/src/components/Homepage/HomepageInsightCard.tsx
+++ b/src/components/Homepage/HomepageInsightCard.tsx
@@ -73,7 +73,7 @@ export const HomepageInsightCard = ({
         <InsightCard>
           You have{' '}
           {maybePluralize(actionItemInsight.ruleIds.length, 'action item')} due
-          by {moment.utc(actionItemInsight.targetDate).local().format('LT on MMMM Do, YYYY')}
+          by {moment(actionItemInsight.targetDate).local().format('MMM Do')}
           {!isNil(entity) && (
             <>
               {' '}

--- a/src/components/Initiatives/InitiativeCard/InitiativeCard.tsx
+++ b/src/components/Initiatives/InitiativeCard/InitiativeCard.tsx
@@ -32,8 +32,7 @@ export const InitiativeCard = ({ initiative }: InitiativeCardProps) => {
       name={initiative.name}
       description={initiative.description}
       badges={[
-        `Due ${moment(initiative.targetDate)
-          .local()
+        `Due ${moment.utc(initiative.targetDate)
           .format('dddd, MMMM Do YYYY')}`,
       ]}
       url={initiativeRef({ id: `${initiative.id}` })}

--- a/src/components/Initiatives/InitiativeCard/InitiativeCard.tsx
+++ b/src/components/Initiatives/InitiativeCard/InitiativeCard.tsx
@@ -32,9 +32,9 @@ export const InitiativeCard = ({ initiative }: InitiativeCardProps) => {
       name={initiative.name}
       description={initiative.description}
       badges={[
-        `Due by ${moment.utc(initiative.targetDate)
+        `Due ${moment(initiative.targetDate)
           .local()
-          .format('LT on MMMM Do, YYYY')}`,
+          .format('dddd, MMMM Do YYYY')}`,
       ]}
       url={initiativeRef({ id: `${initiative.id}` })}
     />

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.test.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.test.tsx
@@ -84,7 +84,7 @@ describe('Initiative Details Page', () => {
     });
     // THEN
     expect(await findByText(name)).toBeVisible();
-    expect(await findByText(/Due by 6:00 AM on June 6th, 2026/)).toBeVisible();
+    expect(await findByText(/Due by June 6th, 2026/)).toBeVisible();
   });
 
   describe('group filter text in metadata', () => {

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeMetadataCard/InitiativeMetadataCardUtils.ts
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeMetadataCard/InitiativeMetadataCardUtils.ts
@@ -23,8 +23,7 @@ export const getTargetDateMessage = (initiative: Initiative) => {
   const remainingDays = daysUntil(initiative.targetDate);
 
   return !isNil(remainingDays) && remainingDays < 0
-  ? `Expired ${moment(initiative.targetDate).local().fromNow()}`
-  : `Due by ${moment(initiative.targetDate)
-        .local()
+  ? `Expired ${moment.utc(initiative.targetDate).fromNow()}`
+  : `Due by ${moment.utc(initiative.targetDate)
         .format('MMMM Do, YYYY')}`;
 };

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeMetadataCard/InitiativeMetadataCardUtils.ts
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeMetadataCard/InitiativeMetadataCardUtils.ts
@@ -23,6 +23,8 @@ export const getTargetDateMessage = (initiative: Initiative) => {
   const remainingDays = daysUntil(initiative.targetDate);
 
   return !isNil(remainingDays) && remainingDays < 0
-    ? `Expired ${moment.utc(initiative.targetDate).local().fromNow()}`
-    : `Due by ${moment.utc(initiative.targetDate).local().format('LT on MMMM Do, YYYY')}`;
+  ? `Expired ${moment(initiative.targetDate).local().fromNow()}`
+  : `Due by ${moment(initiative.targetDate)
+        .local()
+        .format('MMMM Do, YYYY')}`;
 };


### PR DESCRIPTION
## Change description

This partially reverts #183. Namely converting the Initiatives target date to local TZ.

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Screenshots

Before this change, UTC-7 (shifted)
![image](https://github.com/cortexapps/backstage-plugin/assets/32833929/b21ed70e-55e4-42cf-8936-15c14e638821)

After this change, UTC-7 (not shifted)
![image](https://github.com/cortexapps/backstage-plugin/assets/32833929/1225f63e-fef9-40c2-99f0-e1806d0af2e0)

After this change, UTC+2 (not shifted)
![image](https://github.com/cortexapps/backstage-plugin/assets/32833929/07a2e1ba-c4a4-44a9-bf97-f14ed9fab1e5)

## Checklists

### Development

- [ ] The changelog has been updated as appropriate
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
