### PR TITLE
[CET-9978] Error when viewing Bird's Eye Report in Backstage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.11.3
+
+- Fix Bird's Eye Report throwing error when it included archived entities
+
 ### 2.11.2
 
 - Reset the Initiative filters modal when the modal is closed without applying the filters

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/ReportsPage/HeatmapPage/SingleScorecardHeatmap.tsx
+++ b/src/components/ReportsPage/HeatmapPage/SingleScorecardHeatmap.tsx
@@ -26,6 +26,7 @@ import { HomepageEntity } from '../../../api/userInsightTypes';
 import { HeatmapPageFilters, SortBy } from './HeatmapFilters';
 import { ScorecardLadder } from '../../../api/types';
 import { keyBy } from 'lodash';
+import { filterNotUndefined } from '../../../utils/collections';
 
 interface SingleScorecardHeatmapProps {
   entityCategory: string;
@@ -84,9 +85,11 @@ export const SingleScorecardHeatmap = ({
     );
 
     Object.keys(domainIdByEntityId.entitiesToAncestors).forEach(entityId => {
-      map[entityId] = domainIdByEntityId.entitiesToAncestors[
-        parseInt(entityId, 10)
-      ].map(parentId => domainsById[parentId].codeTag);
+      map[entityId] = filterNotUndefined(
+        domainIdByEntityId.entitiesToAncestors[
+          parseInt(entityId, 10)
+        ].map(parentId => domainsById?.[parentId]?.codeTag)
+      );
     });
 
     return map;


### PR DESCRIPTION
## Change description

[CET-9978] Error when viewing Bird's Eye Report in Backstage

Bird's Eye Report trowed an error when attempting to display heatmap with archived entity.

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [ ] The changelog has been updated as appropriate
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


[CET-9978]: https://cortex1.atlassian.net/browse/CET-9978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ