### PR TITLE
CET-9977 Fix for opening initiative filtered by email owner who doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.11.3
+
+- Fix for opening initiative filtered by email owner who doesn't exist
+
 ### 2.11.2
 
 - Reset the Initiative filters modal when the modal is closed without applying the filters

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/Initiatives/InitiativeDetailsPage/InitativeFilterDialog/InitiativeFilterDialogUtils.ts
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitativeFilterDialog/InitiativeFilterDialogUtils.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { isEmpty } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 import {
   RELATION_OWNED_BY,
   parseEntityRef,
@@ -104,7 +104,7 @@ export const getPredicateFilterFromFilters = (
       }
 
       const results = Object.keys(predicateFilters)
-        .filter(id => predicateFilters[id])
+        .filter(id => predicateFilters[id] && !isNil(filter.filters[id]))
         .map(id =>
           filter.generatePredicate(filter.filters[id].value)(componentRef),
         );


### PR DESCRIPTION
## Change description

It was reported, opening initiative in backstage with filter applied (by email owner, who is not on the filter list), results in throwing an error.

> Description here

Additional check is applied to verify if email provided in filter is on the list.

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [ ] The changelog has been updated as appropriate
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
