### PR TITLE
Initiatives filter - my entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2.11.6
 
-- Initiative filter - show my entities
+- Add show my entities filter in Initiatives page
 
 ### 2.11.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.11.6
+
+- Initiative filter - show my entities
+
 ### 2.11.5
 
 - Update how we display Initiative target date

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.11.5",
+  "version": "2.11.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/api/CortexApi.ts
+++ b/src/api/CortexApi.ts
@@ -43,6 +43,7 @@ import {
   EntityDomainAncestorsResponse,
   GetUserInsightsResponse,
   HomepageEntityResponse,
+  UserEntitiesResponse,
 } from './userInsightTypes';
 
 export interface CortexApi {
@@ -110,6 +111,8 @@ export interface CortexApi {
   getInsightsByEmail(): Promise<GetUserInsightsResponse>;
 
   getCatalogEntities(): Promise<HomepageEntityResponse>;
+
+  getUserEntities(): Promise<UserEntitiesResponse>;
 
   getUserPermissions(): Promise<UserPermissionsResponse>;
 

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -53,6 +53,7 @@ import {
   EntityDomainAncestorsResponse,
   GetUserInsightsResponse,
   HomepageEntityResponse,
+  UserEntitiesResponse,
 } from './userInsightTypes';
 
 export const cortexApiRef = createApiRef<CortexApi>({
@@ -314,6 +315,10 @@ export class CortexClient implements CortexApi {
     return this.get(`/api/backstage/v1/homepage/catalog`);
   }
 
+  async getUserEntities(): Promise<UserEntitiesResponse> {
+    return this.get(`/api/backstage/v2/entities/my-entities`);
+  }
+
   async getUserPermissions(): Promise<UserPermissionsResponse> {
     return this.get(`/api/backstage/v2/permissions`);
   }
@@ -472,10 +477,13 @@ export class CortexClient implements CortexApi {
       displayName = profileInfo.displayName;
     }
 
-    const xCortexHeaders = mapValues({
-      'x-cortex-email': email ?? '',
-      'x-cortex-name': displayName ?? '',
-    }, encodeURIComponent);
+    const xCortexHeaders = mapValues(
+      {
+        'x-cortex-email': email ?? '',
+        'x-cortex-name': displayName ?? '',
+      },
+      encodeURIComponent,
+    );
 
     const headers = {
       ...init?.headers,

--- a/src/api/userInsightTypes.ts
+++ b/src/api/userInsightTypes.ts
@@ -90,3 +90,7 @@ export interface HomepageEntityResponse {
 export interface EntityDomainAncestorsResponse {
   entitiesToAncestors: Record<number, number[]>;
 }
+
+export interface UserEntitiesResponse {
+  entityIds: number[];
+}

--- a/src/components/FilterCard/Filters.tsx
+++ b/src/components/FilterCard/Filters.tsx
@@ -57,6 +57,7 @@ export interface FilterValue {
 }
 
 export interface FilterDefinitionWithoutFilters {
+  displayName?: string;
   name: string;
   oneOfDisabled?: boolean;
 }
@@ -72,8 +73,9 @@ export interface FilterDefinitionWithPredicate<T> extends FilterDefinition {
 interface FiltersProps extends FilterDefinition {}
 
 export const Filters: React.FC<FiltersProps> = ({
-  name,
+  displayName,
   filters,
+  name,
   oneOfDisabled,
 }) => {
   const { checkedFilters, setCheckedFilters, oneOf, setOneOf } = useFilter();
@@ -116,7 +118,7 @@ export const Filters: React.FC<FiltersProps> = ({
     <Box display="flex" flexDirection="column">
       <Box display="flex" flexDirection="row" justifyContent="space-between">
         <Typography variant="subtitle2" className={classes.name}>
-          {name}:
+          {displayName ?? name}:
         </Typography>
         {!oneOfDisabled && (
           <Select

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.test.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.test.tsx
@@ -251,7 +251,7 @@ describe('Initiative Details Page', () => {
     });
   });
 
-  it('allows filtering be "my entities"', async () => {
+  it('allows filtering by "my entities"', async () => {
     const initiativeWithScores = Fixtures.initiativeWithScores();
     initiativeWithScores.scores = [
       {

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.test.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.test.tsx
@@ -15,7 +15,7 @@
  */
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { TestApiProvider, wrapInTestApp } from '@backstage/test-utils';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { cortexApiRef } from '../../../api';
@@ -48,6 +48,7 @@ describe('Initiative Details Page', () => {
     },
     getInitiative: async () => Fixtures.initiativeWithScores(),
     getInitiativeActionItems: async () => [],
+    getUserEntities: async () => ({ entityIds: [] }),
     ...overrides,
   });
 
@@ -247,6 +248,138 @@ describe('Initiative Details Page', () => {
       // THEN
       const newPassingInput = getByLabelText('Filter passing rules by has git');
       expect(newPassingInput).not.toBeChecked();
+    });
+  });
+
+  it('allows filtering be "my entities"', async () => {
+    const initiativeWithScores = Fixtures.initiativeWithScores();
+    initiativeWithScores.scores = [
+      {
+        scorePercentage: 0.5,
+        entityTag: 'entity-1',
+      },
+      {
+        scorePercentage: 0.5,
+        entityTag: 'entity-2',
+      },
+    ];
+    initiativeWithScores.rules = [
+      {
+        ruleId: 88,
+        expression: 'git != null',
+        title: 'has git',
+      },
+      {
+        ruleId: 89,
+        expression: 'jira != null',
+        title: 'has jira',
+      },
+    ];
+
+    const { findByText, findByLabelText, getByLabelText, queryByText } =
+      renderInitiativeDetailsPage({
+        getCatalogEntities: async () => {
+          return {
+            entities: [
+              {
+                codeTag: 'entity-1',
+                groupNames: [],
+                id: 234,
+                name: 'Entity 1',
+                serviceGroupTags: [],
+                serviceOwnerEmails: [],
+                type: 'service',
+              },
+              {
+                codeTag: 'entity-2',
+                groupNames: [],
+                id: 235,
+                name: 'Entity 2',
+                serviceGroupTags: [],
+                serviceOwnerEmails: [],
+                type: 'service',
+              },
+            ],
+          };
+        },
+        getUserEntities: async () => ({ entityIds: [234] }),
+        getInitiativeActionItems: async () => {
+          const initiativeItem = {
+            initiativeId: 1,
+            name: 'Test Initiative Name',
+            targetDate: '2026-06-06T06:00:00',
+          };
+
+          const rule1 = {
+            expression: 'git != null',
+            name: 'has git',
+            id: 12,
+            weight: 1,
+          };
+
+          const rule2 = {
+            expression: 'jira != null',
+            name: 'has jira',
+            id: 12,
+            weight: 1,
+          };
+
+          return [
+            {
+              rule: rule1,
+              componentRef: 'entity-1',
+              initiative: initiativeItem,
+            },
+            {
+              rule: rule2,
+              componentRef: 'entity-1',
+              initiative: initiativeItem,
+            },
+            {
+              rule: rule1,
+              componentRef: 'entity-2',
+              initiative: initiativeItem,
+            },
+            {
+              rule: rule2,
+              componentRef: 'entity-2',
+              initiative: initiativeItem,
+            },
+          ];
+        },
+        getInitiative: async () => initiativeWithScores,
+      });
+
+    expect(await findByText('Entity 1')).toBeVisible();
+    expect(await findByText('Entity 2')).toBeVisible();
+
+    // WHEN
+    const filterButton = await findByLabelText('Filter');
+    act(async () => {
+      filterButton.click();
+    });
+
+    const applyFiltersButton = await findByLabelText('Apply filters');
+    await waitFor(() => {
+      expect(applyFiltersButton).toBeVisible();
+    });
+
+    const myEntitiesInput = getByLabelText('Filter myentities by My entities');
+
+    expect(myEntitiesInput).not.toBeChecked();
+
+    act(async () => {
+      fireEvent.click(myEntitiesInput);
+    });
+
+    expect(myEntitiesInput).toBeChecked();
+
+    act(async () => {
+      fireEvent.click(applyFiltersButton);
+    });
+
+    await waitFor(() => {
+      expect(queryByText('Entity 2')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
+++ b/src/components/Initiatives/InitiativeDetailsPage/InitiativeDetailsPage.tsx
@@ -55,12 +55,14 @@ export interface InitiativeDetailsPageProps {
   initiative: InitiativeWithScores;
   actionItems: InitiativeActionItem[];
   entitiesByTag: Record<HomepageEntity['codeTag'], HomepageEntity>;
+  userEntities: string[];
 }
 
 export const InitiativeDetailsPage: React.FC<InitiativeDetailsPageProps> = ({
   actionItems,
   entitiesByTag,
   initiative,
+  userEntities,
 }) => {
   const [activeTab, setActiveTab] = useState(InitiativeDetailsTab.Failing);
   const [isFilterDialogOpen, setIsFilterDialogOpen] = useState(false);
@@ -116,6 +118,7 @@ export const InitiativeDetailsPage: React.FC<InitiativeDetailsPageProps> = ({
     ownerOptionsMap,
     entitiesByTag,
     ruleFilterDefinitions,
+    userEntities,
   });
 
   // Have to store lambda of lambda for React to not eagerly invoke
@@ -258,12 +261,21 @@ const InitiativeDetailsPageWrapper: React.FC = () => {
     return await Promise.all([
       cortexApi.getInitiative(+initiativeId),
       cortexApi.getInitiativeActionItems(+initiativeId),
+      cortexApi.getUserEntities(),
     ]);
   }, []);
 
-  const [initiative, actionItems] = value ?? [undefined, undefined];
+  const [initiative, actionItems, userEntityIds] = value ?? [
+    undefined,
+    undefined,
+    undefined,
+  ];
 
   const { entitiesByTag, loading: loadingEntities } = useEntitiesByTag();
+
+  const userEntities = Object.values(entitiesByTag)
+    .filter(entity => userEntityIds?.entityIds.includes(entity.id))
+    .map(entity => entity.codeTag);
 
   return loading || loadingEntities ? (
     <Progress />
@@ -276,6 +288,7 @@ const InitiativeDetailsPageWrapper: React.FC = () => {
       actionItems={actionItems ?? []}
       entitiesByTag={entitiesByTag}
       initiative={initiative}
+      userEntities={userEntities ?? []}
     />
   );
 };

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -13,14 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { DependencyList, useCallback, useEffect, useMemo, useState, } from 'react';
-import { AnyEntityRef, entityEquals, nullsToUndefined, Predicate, stringifyAnyEntityRef, } from './types';
+import React, {
+  DependencyList,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  AnyEntityRef,
+  entityEquals,
+  nullsToUndefined,
+  Predicate,
+  stringifyAnyEntityRef,
+} from './types';
 import { useAsync } from 'react-use';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { catalogApiRef, getEntityRelations, humanizeEntityRef, } from '@backstage/plugin-catalog-react';
+import {
+  catalogApiRef,
+  getEntityRelations,
+  humanizeEntityRef,
+} from '@backstage/plugin-catalog-react';
 import { groupByString, mapByString, mapValues } from './collections';
-import { Entity, parseEntityRef, RELATION_OWNED_BY, RELATION_PART_OF, } from '@backstage/catalog-model';
-import { defaultGroupRefContext, defaultSystemRefContext, } from './ComponentUtils';
+import {
+  Entity,
+  parseEntityRef,
+  RELATION_OWNED_BY,
+  RELATION_PART_OF,
+} from '@backstage/catalog-model';
+import {
+  defaultGroupRefContext,
+  defaultSystemRefContext,
+} from './ComponentUtils';
 import { cortexApiRef } from '../api';
 import { CortexApi } from '../api/CortexApi';
 import { EntityFilterGroup } from '../filters';
@@ -340,8 +364,12 @@ export function useUiExtensions() {
 export function useInitiativesCustomName() {
   const config = useApi(configApiRef);
 
-  const singular = config.getOptionalString('cortex.initiativeNameOverride.singular') ?? 'Initiative';
-  const plural = config.getOptionalString('cortex.initiativeNameOverride.plural') ?? `${singular}s`;
+  const singular =
+    config.getOptionalString('cortex.initiativeNameOverride.singular') ??
+    'Initiative';
+  const plural =
+    config.getOptionalString('cortex.initiativeNameOverride.plural') ??
+    `${singular}s`;
 
   return { singular, plural };
 }


### PR DESCRIPTION
## Change description

Added new filter to the Initiatives details page - my entities.
Based on new endpoint (`/api/backstage/v2/entities/my-entities`) action items are filtered to display only those which are owned by the user.

![image](https://github.com/cortexapps/backstage-plugin/assets/6973407/3af2c332-39a6-4f6d-a42a-61f8eb20c8d9)

🚨 Needs to be released with https://github.com/cortexapps/brain-backend/pull/6940

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [ ] The changelog has been updated as appropriate
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
