### PR TITLE
CET-11302   [Adobe] Indicator for group by Domain in Historical Report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.11.7
+
+- Add indicator explaining that grouping by domain is not available for historical reports.
+
 ### 2.11.6
 
 - Add show my entities filter in Initiatives page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.11.6",
+  "version": "2.11.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/ReportsPage/ProgressPage/ProgressPage.tsx
+++ b/src/components/ReportsPage/ProgressPage/ProgressPage.tsx
@@ -14,19 +14,8 @@
  * limitations under the License.
  */
 import React, { useCallback, useState } from 'react';
-import {
-  Content,
-  ContentHeader,
-  EmptyState,
-  WarningPanel,
-} from '@backstage/core-components';
-import {
-  FormControl,
-  Grid,
-  InputLabel,
-  MenuItem,
-  Select,
-} from '@material-ui/core';
+import { Content, ContentHeader, EmptyState, WarningPanel, } from '@backstage/core-components';
+import { FormControl, Grid, InputLabel, MenuItem, Select, } from '@material-ui/core';
 import { ScorecardSelector } from '../ScorecardSelector';
 import { useCortexApi, useDropdown } from '../../../utils/hooks';
 import { Lookback } from '../../../utils/lookback';
@@ -56,20 +45,24 @@ export const ProgressPage = () => {
   const [selectedScorecardId, setSelectedScorecardId] = useState<
     number | undefined
   >(initialScorecardId);
-  const setSelectedScorecardIdAndNavigate = useCallback((selectedScorecardId?: number) => {
-    setSelectedScorecardId(selectedScorecardId);
+  const setSelectedScorecardIdAndNavigate = useCallback(
+    (selectedScorecardId?: number) => {
+      setSelectedScorecardId(selectedScorecardId);
 
-    const targetUrl = stringifyUrl({ url: location.pathname, query: {
-      scorecardId: selectedScorecardId
-    }});
+      const targetUrl = stringifyUrl({
+        url: location.pathname,
+        query: {
+          scorecardId: selectedScorecardId,
+        },
+      });
 
-    navigate(targetUrl, { replace: true });
-  }, [setSelectedScorecardId, location.pathname, navigate]);
+      navigate(targetUrl, { replace: true });
+    },
+    [setSelectedScorecardId, location.pathname, navigate],
+  );
 
   const [lookback, setLookback] = useDropdown(Lookback.MONTHS_1);
-  const [groupBy, setGroupBy] = useState<GroupByOption>(
-    GroupByOption.ENTITY,
-  );
+  const [groupBy, setGroupBy] = useState<GroupByOption>(GroupByOption.ENTITY);
   const [selectedRule, setSelectedRule] = useDropdown<string>(
     defaultRule.value,
   );
@@ -94,11 +87,11 @@ export const ProgressPage = () => {
 
   const scorecardsResult = useCortexApi(api => api.getScorecards());
 
-  if (groupBy === GroupByOption.LEVEL) {
+  if (groupBy === GroupByOption.LEVEL || groupBy === GroupByOption.DOMAIN) {
     return (
-        <WarningPanel severity="error" title="Functionality not supported.">
-          Group by for levels is not supported yet.
-        </WarningPanel>
+      <WarningPanel severity="error" title="Functionality not supported.">
+        Group by for levels is not supported yet.
+      </WarningPanel>
     );
   }
 


### PR DESCRIPTION
## Change description

Currently selecting "Group by" Domain on Progress report is not supported by our backend - throwing 400.
This change adds guard on backstage-plugin level.

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [ ] The changelog has been updated as appropriate
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
