### PR TITLE
Add new syncChunkSize config value

### DIFF
--- a/.github/workflows/publish-gh-registry.yml
+++ b/.github/workflows/publish-gh-registry.yml
@@ -27,6 +27,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn tsc
       - run: yarn build
+      - run: ./scripts/add_publish_to_github_config.sh
       - run: |
           yarn version --new-version $(jq -r .version < package.json)-${GITHUB_SHA}
           yarn publish --non-interactive

--- a/README.md
+++ b/README.md
@@ -135,14 +135,13 @@ cortex:
   hideSettings: true
 ```
 
-12. (Optional) When performing manual entity sync in the Settings page, you can choose to use gzip to compress the entities by updating `app-config.yaml` with the parameter `syncWithGzip`. You must also update the Backstage HTTP proxy to allow the `Content-Encoding` header.
+12. (Optional) When performing manual entity sync in the Settings page, you can choose to use gzip to compress the entities by updating `app-config.yaml` with the parameter `syncWithGzip`. You must also update the Backstage HTTP proxy to allow the `Content-Encoding` header. Additionally, you can also configure the `syncChunkSize` parameter if the default of `1000` does suit your use case.
 
 ```yaml
 cortex:
   syncWithGzip: true
-```
+  syncChunkSize: 1000
 
-```yaml
 proxy:
   '/cortex':
     target: ${CORTEX_BACKEND_HOST_URL}

--- a/config.d.ts
+++ b/config.d.ts
@@ -55,6 +55,13 @@ export interface Config {
     syncWithGzip?: boolean;
 
     /**
+     * The 'syncChunkSize' attribute. Determines the chunk size used when performing the Cortex
+     * Backstage entity sync. If not provided, this defaults to 1000.
+     * @visibility frontend
+     */
+    syncChunkSize?: number;
+
+    /**
      * @deepVisibility frontend
      */
     header?: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.12.3",
+  "version": "2.13.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/scripts/add_publish_to_github_config.sh
+++ b/scripts/add_publish_to_github_config.sh
@@ -1,0 +1,5 @@
+echo "
+//npm.pkg.github.com/:_authToken=${GITHUB_PASSWORD}
+@cortexapps:registry=https://npm.pkg.github.com
+engine-strict=true
+" > .npmrc

--- a/src/api/CortexApi.ts
+++ b/src/api/CortexApi.ts
@@ -105,6 +105,7 @@ export interface CortexApi {
     entities: Entity[],
     shouldGzipBody: boolean,
     teamOverrides?: TeamOverrides,
+    chunkSize?: number,
   ): Promise<EntitySyncProgress>;
 
   getEntitySyncProgress(): Promise<EntitySyncProgress>;

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -95,7 +95,9 @@ export class CortexClient implements CortexApi {
     entities: Entity[],
     gzipContents: boolean,
     teamOverrides?: TeamOverrides,
+    chunkSize?: number,
   ): Promise<EntitySyncProgress> {
+    const syncChunkSize = chunkSize ?? DEFAULT_CHUNK_SIZE;
     const post = async (path: string, body?: any) => {
       return gzipContents
         ? await this.postVoidWithGzipBody(path, body)
@@ -104,7 +106,7 @@ export class CortexClient implements CortexApi {
 
     await this.postVoid('/api/backstage/v2/entities/sync-init');
 
-    for (let customMappingsChunk of chunk(entities, CHUNK_SIZE)) {
+    for (let customMappingsChunk of chunk(entities, syncChunkSize)) {
       await post(`/api/backstage/v2/entities/sync-chunked`, {
         entities: customMappingsChunk,
       });
@@ -112,7 +114,7 @@ export class CortexClient implements CortexApi {
 
     for (let teamOverridesTeamChunk of chunk(
       teamOverrides?.teams ?? [],
-      CHUNK_SIZE,
+      syncChunkSize,
     )) {
       await post(`/api/backstage/v2/entities/sync-chunked`, {
         entities: [],
@@ -125,7 +127,7 @@ export class CortexClient implements CortexApi {
 
     for (let teamOverridesRelationshipsChunk of chunk(
       teamOverrides?.relationships ?? [],
-      CHUNK_SIZE,
+      syncChunkSize,
     )) {
       await post(`/api/backstage/v2/entities/sync-chunked`, {
         entities: [],
@@ -532,4 +534,4 @@ export class CortexClient implements CortexApi {
   }
 }
 
-const CHUNK_SIZE = 1000;
+const DEFAULT_CHUNK_SIZE = 1000;

--- a/src/components/SettingsPage/SettingsPage.test.tsx
+++ b/src/components/SettingsPage/SettingsPage.test.tsx
@@ -77,11 +77,17 @@ describe('<SettingsPage/>', () => {
     { parentTeamTag: team1.teamTag, childTeamTag: team2.teamTag },
   ];
 
-  const configApi: (syncWithGzip?: boolean) => Partial<ConfigApi> =
-    syncWithGzip => ({
+  const configApi: (syncWithGzip?: boolean, syncChunkSize?: number) => Partial<ConfigApi> =
+    (syncWithGzip, syncChunkSize) => ({
       getOptionalBoolean(key) {
         if (key === 'cortex.syncWithGzip') {
           return syncWithGzip ?? false;
+        }
+        return undefined;
+      },
+      getOptionalNumber(key) {
+        if (key === 'cortex.syncChunkSize') {
+          return syncChunkSize ?? undefined;
         }
         return undefined;
       },

--- a/src/components/SettingsPage/SettingsPage.test.tsx
+++ b/src/components/SettingsPage/SettingsPage.test.tsx
@@ -158,6 +158,7 @@ describe('<SettingsPage/>', () => {
       ],
       false,
       { teams, relationships },
+      undefined,
     );
   });
 
@@ -209,6 +210,7 @@ describe('<SettingsPage/>', () => {
     expect(cortexApi.submitEntitySync).toHaveBeenLastCalledWith(
       [],
       false,
+      undefined,
       undefined,
     );
   });
@@ -262,6 +264,7 @@ describe('<SettingsPage/>', () => {
       [component1],
       false,
       undefined,
+      undefined,
     );
   });
 
@@ -292,6 +295,38 @@ describe('<SettingsPage/>', () => {
       [component1, component2],
       true,
       { teams, relationships },
+      undefined,
+    );
+  });
+
+  it('should submit entity sync customizable chunk size', async () => {
+    cortexApi.submitEntitySync.mockResolvedValue({ percentage: null });
+    cortexApi.getEntitySyncProgress.mockResolvedValue({ percentage: null });
+    cortexApi.getLastEntitySyncTime.mockResolvedValue({
+      lastSynced: null,
+    });
+    const { clickButton, queryByLabelText } = renderWrapped(
+      <SettingsPage />,
+      cortexApi,
+      {},
+      [catalogApiRef, catalogApi],
+      [configApiRef, configApi(true, 1)],
+      [extensionApiRef, extensionApi],
+    );
+
+    await clickButton('Sync Entities');
+    await waitFor(() =>
+      expect(queryByLabelText('Sync Entities')).toHaveAttribute(
+        'aria-busy',
+        'false',
+      ),
+    );
+
+    expect(cortexApi.submitEntitySync).toHaveBeenLastCalledWith(
+      [component1, component2],
+      true,
+      { teams, relationships },
+      1,
     );
   });
 

--- a/src/components/SettingsPage/SyncCard.tsx
+++ b/src/components/SettingsPage/SyncCard.tsx
@@ -117,6 +117,8 @@ export const SyncCard = () => {
     const entities = await getBackstageEntities();
     const shouldGzipBody =
       config.getOptionalBoolean('cortex.syncWithGzip') ?? false;
+      const syncChunkSize =
+      config.getOptionalNumber('cortex.syncChunkSize');
     const groupOverrides = await extensionApi.getTeamOverrides?.(entities);
     setCortexSyncError(undefined);
     try {
@@ -124,6 +126,7 @@ export const SyncCard = () => {
         entities,
         shouldGzipBody,
         groupOverrides,
+        syncChunkSize,
       );
       setSyncTaskProgressPercentage(progress.percentage);
     } catch (e: any) {


### PR DESCRIPTION
## Change description

Allows users to change the size of sync chunks via config. Notable helps to solve problem where users were getting a 413 request too large from the backstage server when attempting to send large entities.

example usage:
```
# 30 entities at a time
cortex:
  syncWithGzip: true
  syncChunkSize: 30
```

https://cortex1.atlassian.net/browse/CET-12628?atlOrigin=eyJpIjoiZGU3Y2Q4ZjQzMGE1NDI1Yzg4NTdlM2MxOTg2YWQ4ZmUiLCJwIjoiaiJ9

## Type of change

Tested against dev environment with chunk size of 3 and 63 entities, confirmed 21 chunk requests sent

## Checklists

### Development

- [ ] The changelog has been updated as appropriate
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
