### PR TITLE
CET-13421 Adobe performance with Backstage on Bird's Eye report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.12.4
 
 - Performance improvements for the Bird's Eye report
+- Depends on Cortex version 0.0.336
 
 ### 2.12.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.12.4
+
+- Performance improvements for the Bird's Eye report
+
 ### 2.12.3
 
 - Use @cortexapps/birdseye from NPM registry

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/api/CortexApi.ts
+++ b/src/api/CortexApi.ts
@@ -13,56 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  DomainHierarchiesResponse,
-  EntitySyncProgress,
-  ExpirationResponse,
-  GroupByOption,
-  Initiative,
-  InitiativeActionItem,
-  InitiativeWithScores,
-  JobsResponse,
-  LastEntitySyncTime,
-  OncallsResponse,
-  Scorecard,
-  ScorecardLadder,
-  ScorecardResult,
-  ScorecardRuleExemptionResult,
-  ScorecardScoreNextSteps,
-  ScorecardServiceScore,
-  ScoresByIdentifier,
-  ServiceGroupsResponse,
-  ServiceScorecardScore,
-  TeamHierarchiesResponse,
-  UserPermissionsResponse,
-} from './types';
+import { DomainHierarchiesResponse, EntitySyncProgress, ExpirationResponse, GroupByOption, Initiative, InitiativeActionItem, InitiativeWithScores, JobsResponse, LastEntitySyncTime, OncallsResponse, Scorecard, ScorecardLadder, ScorecardResult, ScorecardRuleExemptionResult, ScorecardScoreNextSteps, ScorecardServiceScore, ScoresByIdentifier, ServiceGroupsResponse, ServiceScorecardScore, TeamHierarchiesResponse, UserPermissionsResponse, } from './types';
 import { Entity } from '@backstage/catalog-model';
 import { Moment } from 'moment/moment';
 import { AnyEntityRef } from '../utils/types';
 import { TeamOverrides } from '@cortexapps/backstage-plugin-extensions';
-import {
-  EntityDomainAncestorsResponse,
-  GetUserInsightsResponse,
-  HomepageEntityResponse,
-  UserEntitiesResponse,
-} from './userInsightTypes';
-import {
-  Domain,
-  StringIndexable,
-  TeamDetails,
-  TeamResponse,
-} from '@cortexapps/birdseye';
+import { EntityDomainAncestorsResponse, GetUserInsightsResponse, HomepageEntityResponse, UserEntitiesResponse, } from './userInsightTypes';
+import { Domain, StringIndexable, TeamDetails, TeamResponse, } from '@cortexapps/birdseye';
 
 export interface CortexApi {
   getScorecards(): Promise<Scorecard[]>;
+
   getScorecard(scorecardId: number): Promise<Scorecard | undefined>;
+
   getScorecardLadders(scorecardId: number): Promise<ScorecardLadder[]>;
+
   getScorecardScores(scorecardId: number): Promise<ScorecardServiceScore[]>;
+
   getScorecardRuleExemptions(
     scorecardId: number,
   ): Promise<ScorecardRuleExemptionResult>;
 
   getServiceScores(entityRef: AnyEntityRef): Promise<ServiceScorecardScore[]>;
+
   getServiceNextSteps(
     entityRef: AnyEntityRef,
     scorecardId: number,
@@ -74,6 +47,7 @@ export interface CortexApi {
     startDate?: Moment,
     endDate?: Moment,
   ): Promise<ScorecardResult[]>;
+
   getAverageHistoricalScores(
     scorecardId: number,
     groupBy: GroupByOption,
@@ -89,14 +63,19 @@ export interface CortexApi {
   ): Promise<ScoresByIdentifier[]>;
 
   getInitiatives(): Promise<Initiative[]>;
+
   getInitiative(id: number): Promise<InitiativeWithScores>;
+
   getInitiativeActionItems(id: number): Promise<InitiativeActionItem[]>;
+
   getInitiativeActionItemsForTeam(
     entityRef: AnyEntityRef,
   ): Promise<InitiativeActionItem[]>;
+
   getComponentActionItems(
     entityRef: AnyEntityRef,
   ): Promise<InitiativeActionItem[]>;
+
   getBulkComponentActionItems(
     entityRefs: AnyEntityRef[],
   ): Promise<InitiativeActionItem[]>;
@@ -138,7 +117,7 @@ export interface CortexApi {
 
   getAllTeams(): Promise<{ teams: TeamResponse[] }>;
 
-  getAllTeamsByEntityId(): Promise<{
+  getTeamsByEntityIds(entityIds: number[]): Promise<{
     teamsByEntityId: StringIndexable<TeamDetails[]>;
   }>;
 

--- a/src/api/CortexApi.ts
+++ b/src/api/CortexApi.ts
@@ -13,13 +13,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DomainHierarchiesResponse, EntitySyncProgress, ExpirationResponse, GroupByOption, Initiative, InitiativeActionItem, InitiativeWithScores, JobsResponse, LastEntitySyncTime, OncallsResponse, Scorecard, ScorecardLadder, ScorecardResult, ScorecardRuleExemptionResult, ScorecardScoreNextSteps, ScorecardServiceScore, ScoresByIdentifier, ServiceGroupsResponse, ServiceScorecardScore, TeamHierarchiesResponse, UserPermissionsResponse, } from './types';
+import {
+  DomainHierarchiesResponse,
+  EntitySyncProgress,
+  ExpirationResponse,
+  GroupByOption,
+  Initiative,
+  InitiativeActionItem,
+  InitiativeWithScores,
+  JobsResponse,
+  LastEntitySyncTime,
+  OncallsResponse,
+  Scorecard,
+  ScorecardLadder,
+  ScorecardResult,
+  ScorecardRuleExemptionResult,
+  ScorecardScoreNextSteps,
+  ScorecardServiceScore,
+  ScoresByIdentifier,
+  ServiceGroupsResponse,
+  ServiceScorecardScore,
+  TeamHierarchiesResponse,
+  UserPermissionsResponse,
+} from './types';
 import { Entity } from '@backstage/catalog-model';
 import { Moment } from 'moment/moment';
 import { AnyEntityRef } from '../utils/types';
 import { TeamOverrides } from '@cortexapps/backstage-plugin-extensions';
-import { EntityDomainAncestorsResponse, GetUserInsightsResponse, HomepageEntityResponse, UserEntitiesResponse, } from './userInsightTypes';
-import { Domain, StringIndexable, TeamDetails, TeamResponse, } from '@cortexapps/birdseye';
+import {
+  EntityDomainAncestorsResponse,
+  GetUserInsightsResponse,
+  HomepageEntityResponse,
+  UserEntitiesResponse,
+} from './userInsightTypes';
+import {
+  Domain,
+  StringIndexable,
+  TeamDetails,
+  TeamResponse,
+} from '@cortexapps/birdseye';
 
 export interface CortexApi {
   getScorecards(): Promise<Scorecard[]>;

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -14,7 +14,29 @@
  * limitations under the License.
  */
 
-import { DomainHierarchiesResponse, EntitySyncProgress, ExpirationResponse, GroupByOption, Initiative, InitiativeActionItem, InitiativeWithScores, JobsResponse, LastEntitySyncTime, OncallsResponse, Scorecard, ScorecardLadder, ScorecardResult, ScorecardRuleExemptionResult, ScorecardScoreNextSteps, ScorecardServiceScore, ScoresByIdentifier, ServiceGroupsResponse, ServiceScorecardScore, TeamHierarchiesResponse, UserPermissionsResponse, } from './types';
+import {
+  DomainHierarchiesResponse,
+  EntitySyncProgress,
+  ExpirationResponse,
+  GroupByOption,
+  Initiative,
+  InitiativeActionItem,
+  InitiativeWithScores,
+  JobsResponse,
+  LastEntitySyncTime,
+  OncallsResponse,
+  Scorecard,
+  ScorecardLadder,
+  ScorecardResult,
+  ScorecardRuleExemptionResult,
+  ScorecardScoreNextSteps,
+  ScorecardServiceScore,
+  ScoresByIdentifier,
+  ServiceGroupsResponse,
+  ServiceScorecardScore,
+  TeamHierarchiesResponse,
+  UserPermissionsResponse,
+} from './types';
 import { CortexApi } from './CortexApi';
 import { Entity } from '@backstage/catalog-model';
 import { Buffer } from 'buffer';
@@ -22,10 +44,24 @@ import { Moment } from 'moment/moment';
 import { chunk, mapValues } from 'lodash';
 import { AnyEntityRef, stringifyAnyEntityRef } from '../utils/types';
 import { TeamOverrides } from '@cortexapps/backstage-plugin-extensions';
-import { createApiRef, DiscoveryApi, IdentityApi, } from '@backstage/core-plugin-api';
+import {
+  createApiRef,
+  DiscoveryApi,
+  IdentityApi,
+} from '@backstage/core-plugin-api';
 import { gzipSync } from 'zlib';
-import { EntityDomainAncestorsResponse, GetUserInsightsResponse, HomepageEntityResponse, UserEntitiesResponse, } from './userInsightTypes';
-import { Domain, StringIndexable, TeamDetails, TeamResponse, } from '@cortexapps/birdseye';
+import {
+  EntityDomainAncestorsResponse,
+  GetUserInsightsResponse,
+  HomepageEntityResponse,
+  UserEntitiesResponse,
+} from './userInsightTypes';
+import {
+  Domain,
+  StringIndexable,
+  TeamDetails,
+  TeamResponse,
+} from '@cortexapps/birdseye';
 
 export const cortexApiRef = createApiRef<CortexApi>({
   id: 'plugin.cortex.service',

--- a/src/api/CortexClient.ts
+++ b/src/api/CortexClient.ts
@@ -14,29 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  DomainHierarchiesResponse,
-  EntitySyncProgress,
-  ExpirationResponse,
-  GroupByOption,
-  Initiative,
-  InitiativeActionItem,
-  InitiativeWithScores,
-  JobsResponse,
-  LastEntitySyncTime,
-  OncallsResponse,
-  Scorecard,
-  ScorecardLadder,
-  ScorecardResult,
-  ScorecardRuleExemptionResult,
-  ScorecardScoreNextSteps,
-  ScorecardServiceScore,
-  ScoresByIdentifier,
-  ServiceGroupsResponse,
-  ServiceScorecardScore,
-  TeamHierarchiesResponse,
-  UserPermissionsResponse,
-} from './types';
+import { DomainHierarchiesResponse, EntitySyncProgress, ExpirationResponse, GroupByOption, Initiative, InitiativeActionItem, InitiativeWithScores, JobsResponse, LastEntitySyncTime, OncallsResponse, Scorecard, ScorecardLadder, ScorecardResult, ScorecardRuleExemptionResult, ScorecardScoreNextSteps, ScorecardServiceScore, ScoresByIdentifier, ServiceGroupsResponse, ServiceScorecardScore, TeamHierarchiesResponse, UserPermissionsResponse, } from './types';
 import { CortexApi } from './CortexApi';
 import { Entity } from '@backstage/catalog-model';
 import { Buffer } from 'buffer';
@@ -44,24 +22,10 @@ import { Moment } from 'moment/moment';
 import { chunk, mapValues } from 'lodash';
 import { AnyEntityRef, stringifyAnyEntityRef } from '../utils/types';
 import { TeamOverrides } from '@cortexapps/backstage-plugin-extensions';
-import {
-  createApiRef,
-  DiscoveryApi,
-  IdentityApi,
-} from '@backstage/core-plugin-api';
+import { createApiRef, DiscoveryApi, IdentityApi, } from '@backstage/core-plugin-api';
 import { gzipSync } from 'zlib';
-import {
-  EntityDomainAncestorsResponse,
-  GetUserInsightsResponse,
-  HomepageEntityResponse,
-  UserEntitiesResponse,
-} from './userInsightTypes';
-import {
-  Domain,
-  StringIndexable,
-  TeamDetails,
-  TeamResponse,
-} from '@cortexapps/birdseye';
+import { EntityDomainAncestorsResponse, GetUserInsightsResponse, HomepageEntityResponse, UserEntitiesResponse, } from './userInsightTypes';
+import { Domain, StringIndexable, TeamDetails, TeamResponse, } from '@cortexapps/birdseye';
 
 export const cortexApiRef = createApiRef<CortexApi>({
   id: 'plugin.cortex.service',
@@ -363,10 +327,12 @@ export class CortexClient implements CortexApi {
     return this.get(`/api/backstage/v1/teams`);
   }
 
-  async getAllTeamsByEntityId(): Promise<{
+  async getTeamsByEntityIds(entityIds: number[]): Promise<{
     teamsByEntityId: StringIndexable<TeamDetails[]>;
   }> {
-    return this.get(`/api/backstage/v1/ownership/entities/teams`);
+    return this.get(`/api/backstage/v1/ownership/entities/teams`, {
+      entityIds: entityIds.map(id => id.toString()),
+    });
   }
 
   async getServiceGroups(): Promise<ServiceGroupsResponse> {

--- a/src/components/ReportsPage/HeatmapPage/HeatmapPage.tsx
+++ b/src/components/ReportsPage/HeatmapPage/HeatmapPage.tsx
@@ -14,13 +14,21 @@
  * limitations under the License.
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import { ContentHeader, EmptyState, Progress, } from '@backstage/core-components';
+import {
+  ContentHeader,
+  EmptyState,
+  Progress,
+} from '@backstage/core-components';
 import { Grid } from '@material-ui/core';
 import { ScorecardSelector } from '../ScorecardSelector';
-import { useCortexApi, useCortexApiMemorized, useEntitiesByTag, } from '../../../utils/hooks';
+import {
+  useCortexApi,
+  useCortexApiMemoized,
+  useEntitiesByTag,
+} from '../../../utils/hooks';
 import { CopyButton } from '../../Common/CopyButton';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
-import { isFunction } from 'lodash';
+import { isEmpty, isFunction, isNil } from 'lodash';
 import { stringifyUrl } from 'query-string';
 import { defaultInitial, Filters, HeaderType } from '@cortexapps/birdseye';
 import { HeatmapTable } from './HeatmapTable';
@@ -109,9 +117,9 @@ export const HeatmapPage = () => {
     api.getAllTeams(),
   );
   const { value: teamsByEntityId, loading: isLoadingTeamsByEntityId } =
-    useCortexApiMemorized(
+    useCortexApiMemoized(
       async api =>
-        scores && scores.length > 0
+        !isNil(scores) && !isEmpty(scores)
           ? await api.getTeamsByEntityIds(scores.map(score => score.serviceId))
           : undefined,
       [scores],

--- a/src/components/ReportsPage/HeatmapPage/HeatmapPage.tsx
+++ b/src/components/ReportsPage/HeatmapPage/HeatmapPage.tsx
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import {
-  ContentHeader,
-  EmptyState,
-  Progress,
-} from '@backstage/core-components';
+import { ContentHeader, EmptyState, Progress, } from '@backstage/core-components';
 import { Grid } from '@material-ui/core';
 import { ScorecardSelector } from '../ScorecardSelector';
-import { useCortexApi, useEntitiesByTag } from '../../../utils/hooks';
+import { useCortexApi, useCortexApiMemorized, useEntitiesByTag, } from '../../../utils/hooks';
 import { CopyButton } from '../../Common/CopyButton';
-import { useSearchParams, useNavigate, useLocation } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { isFunction } from 'lodash';
 import { stringifyUrl } from 'query-string';
 import { defaultInitial, Filters, HeaderType } from '@cortexapps/birdseye';
@@ -113,7 +109,13 @@ export const HeatmapPage = () => {
     api.getAllTeams(),
   );
   const { value: teamsByEntityId, loading: isLoadingTeamsByEntityId } =
-    useCortexApi(api => api.getAllTeamsByEntityId());
+    useCortexApiMemorized(
+      async api =>
+        scores && scores.length > 0
+          ? await api.getTeamsByEntityIds(scores.map(score => score.serviceId))
+          : undefined,
+      [scores],
+    );
   const { value: domainHierarchies, loading: isLoadingDomainHierarchies } =
     useCortexApi(api => api.getDomainHierarchies());
   const { value: teamHierarchies, loading: isLoadingTeamHierarchies } =

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -13,14 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { DependencyList, useCallback, useEffect, useMemo, useState, } from 'react';
-import { AnyEntityRef, entityEquals, nullsToUndefined, Predicate, stringifyAnyEntityRef, } from './types';
+import React, {
+  DependencyList,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  AnyEntityRef,
+  entityEquals,
+  nullsToUndefined,
+  Predicate,
+  stringifyAnyEntityRef,
+} from './types';
 import { useAsync } from 'react-use';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { catalogApiRef, getEntityRelations, humanizeEntityRef, } from '@backstage/plugin-catalog-react';
+import {
+  catalogApiRef,
+  getEntityRelations,
+  humanizeEntityRef,
+} from '@backstage/plugin-catalog-react';
 import { groupByString, mapByString, mapValues } from './collections';
-import { Entity, parseEntityRef, RELATION_OWNED_BY, RELATION_PART_OF, } from '@backstage/catalog-model';
-import { defaultGroupRefContext, defaultSystemRefContext, } from './ComponentUtils';
+import {
+  Entity,
+  parseEntityRef,
+  RELATION_OWNED_BY,
+  RELATION_PART_OF,
+} from '@backstage/catalog-model';
+import {
+  defaultGroupRefContext,
+  defaultSystemRefContext,
+} from './ComponentUtils';
 import { cortexApiRef } from '../api';
 import { CortexApi } from '../api/CortexApi';
 import { EntityFilterGroup } from '../filters';
@@ -220,24 +244,24 @@ export function useCortexApi<T>(
   }, deps);
 }
 
-export function useCortexApiMemorized<T>(
+export function useCortexApiMemoized<T>(
   f: (api: CortexApi) => Promise<T>,
   deps: any[] = [],
 ) {
   const cortexApi = useApi(cortexApiRef);
 
-  return useAsyncMemorized(async () => {
+  return useAsyncMemoized(async () => {
     return await f(cortexApi);
   }, deps);
 }
 
-function useAsyncMemorized<T>(f: () => Promise<T>, deps: any[]) {
+function useAsyncMemoized<T>(f: () => Promise<T>, deps: any[]) {
   const [cache, setCache] = useState<Record<string, any>>({});
   const cacheKey = useMemo(() => JSON.stringify(deps), [deps]);
-  const cachedResult = useMemo(() => cache[cacheKey], [cacheKey, cache]);
 
   return useAsync(async () => {
-    if (cachedResult !== undefined) {
+    const cachedResult = cache[cacheKey];
+    if (!isNil(cachedResult)) {
       return cachedResult;
     }
 

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -13,38 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, {
-  DependencyList,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
-import {
-  AnyEntityRef,
-  entityEquals,
-  nullsToUndefined,
-  Predicate,
-  stringifyAnyEntityRef,
-} from './types';
+import React, { DependencyList, useCallback, useEffect, useMemo, useState, } from 'react';
+import { AnyEntityRef, entityEquals, nullsToUndefined, Predicate, stringifyAnyEntityRef, } from './types';
 import { useAsync } from 'react-use';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import {
-  catalogApiRef,
-  getEntityRelations,
-  humanizeEntityRef,
-} from '@backstage/plugin-catalog-react';
+import { catalogApiRef, getEntityRelations, humanizeEntityRef, } from '@backstage/plugin-catalog-react';
 import { groupByString, mapByString, mapValues } from './collections';
-import {
-  Entity,
-  parseEntityRef,
-  RELATION_OWNED_BY,
-  RELATION_PART_OF,
-} from '@backstage/catalog-model';
-import {
-  defaultGroupRefContext,
-  defaultSystemRefContext,
-} from './ComponentUtils';
+import { Entity, parseEntityRef, RELATION_OWNED_BY, RELATION_PART_OF, } from '@backstage/catalog-model';
+import { defaultGroupRefContext, defaultSystemRefContext, } from './ComponentUtils';
 import { cortexApiRef } from '../api';
 import { CortexApi } from '../api/CortexApi';
 import { EntityFilterGroup } from '../filters';
@@ -242,6 +218,37 @@ export function useCortexApi<T>(
   return useAsync(async () => {
     return await f(cortexApi);
   }, deps);
+}
+
+export function useCortexApiMemorized<T>(
+  f: (api: CortexApi) => Promise<T>,
+  deps: any[] = [],
+) {
+  const cortexApi = useApi(cortexApiRef);
+
+  return useAsyncMemorized(async () => {
+    return await f(cortexApi);
+  }, deps);
+}
+
+function useAsyncMemorized<T>(f: () => Promise<T>, deps: any[]) {
+  const [cache, setCache] = useState<Record<string, any>>({});
+  const cacheKey = useMemo(() => JSON.stringify(deps), [deps]);
+  const cachedResult = useMemo(() => cache[cacheKey], [cacheKey, cache]);
+
+  return useAsync(async () => {
+    if (cachedResult !== undefined) {
+      return cachedResult;
+    }
+
+    const result = await f();
+    setCache(prevCache => ({
+      ...prevCache,
+      [cacheKey]: result,
+    }));
+
+    return result;
+  }, [cacheKey]);
 }
 
 const useServiceGroups = () => {


### PR DESCRIPTION
## Change description

CET-13421 Adobe performance with Backstage on Bird's Eye report

**Requires BE**: https://github.com/cortexapps/brain-backend/pull/8087

Changed fetching owners for entities to fetch only those for entities for which we have scores for scorecard.

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [x] The changelog has been updated as appropriate
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
