### PR TITLE
feat: expose the HomepageInsightsCard, so I can be added to any page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cortexapps/backstage-plugin",
-  "version": "2.13.5",
+  "version": "2.13.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * Copyright 2024 Cortex Applications, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 import CortexIconComponent from './assets/cortex.icon.svg';
 import { IconComponent } from '@backstage/core-plugin-api';
 import('@cortexapps/birdseye/index.css' as any);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,19 @@
 /*
+ * Copyright 2025 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * Copyright 2024 Cortex Applications, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +41,7 @@ export {
   SystemCortexContent,
   extendableCortexPlugin,
   CortexHomepage,
+  CortexInsightsCard,
 } from './plugin';
 export { extensionApiRef } from './api/ExtensionApi';
 export type { CortexScorecardWidgetProps } from './components/CortexScorecardWidget/CortexScorecardWidget';

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,19 @@
 /*
+ * Copyright 2025 Cortex Applications, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * Copyright 2024 Cortex Applications, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -199,6 +214,18 @@ export const CortexHomepage = cortexPlugin.provide(
     component: {
       lazy: () =>
         import('./components/Homepage/Homepage').then(m => m.Homepage),
+    },
+  }),
+);
+
+export const CortexInsightsCard = cortexPlugin.provide(
+  createComponentExtension({
+    name: 'CortexHomepage',
+    component: {
+      lazy: () =>
+        import('./components/Homepage/HomepageInsights').then(
+          m => m.HomepageInsights,
+        ),
     },
   }),
 );

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * Copyright 2024 Cortex Applications, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 import {
   BackstagePlugin,
   createApiFactory,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -205,7 +205,7 @@ export const CortexHomepage = cortexPlugin.provide(
 
 export const CortexInsightsCard = cortexPlugin.provide(
   createComponentExtension({
-    name: 'CortexHomepage',
+    name: 'CortexInsightsCard',
     component: {
       lazy: () =>
         import('./components/Homepage/HomepageInsights').then(


### PR DESCRIPTION
## Change description

The HomepageInsightsCard seems is very useful, however having it exposed only in the predefined CortexHomepage is not Ideal as we can't customizing that specific page.

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [X] Improvement (improves codebase without changing functionality)

## Checklists

### Development

- [ ] The changelog has been updated as appropriate
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
